### PR TITLE
fix(dynacat): revert emby property name to glance_api_key

### DIFF
--- a/kubernetes/apps/selfhosted/dynacat/app/externalsecret.yaml
+++ b/kubernetes/apps/selfhosted/dynacat/app/externalsecret.yaml
@@ -28,7 +28,7 @@ spec:
     - secretKey: EMBY_API_KEY
       remoteRef:
         key: emby
-        property: dynacat_api_key
+        property: glance_api_key
     - secretKey: READARR_API_KEY
       remoteRef:
         key: readarr


### PR DESCRIPTION
## Summary
Hotfix follow-up to #177. The bulk sed during the glance→dynacat rename over-matched the 1Password ItemField label `glance_api_key` inside the unrelated 1P item `emby`. That field stayed named `glance_api_key` in 1Password (only its value matters), so ExternalSecret fails with `expected one 1Password ItemField matching: 'dynacat_api_key' in 'emby', got 0`. Reverts that one property reference.

## Test plan
- [ ] flux-local CI green
- [ ] After merge: ExternalSecret `dynacat` Ready=True
- [ ] dynacat pod 1/1 Running, all 10 secret keys populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)