### PR TITLE
fix(dynacat): cluster-internal Gatus URL + recent-restart pod filter

### DIFF
--- a/kubernetes/apps/observability/gatus/app/ciliumnetworkpolicy.yaml
+++ b/kubernetes/apps/observability/gatus/app/ciliumnetworkpolicy.yaml
@@ -22,6 +22,9 @@ spec:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: observability
             app.kubernetes.io/name: prometheus
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: selfhosted
+            app.kubernetes.io/name: dynacat
       toPorts:
         - ports:
             - port: "80"

--- a/kubernetes/apps/selfhosted/dynacat/app/configmap.yaml
+++ b/kubernetes/apps/selfhosted/dynacat/app/configmap.yaml
@@ -46,7 +46,7 @@ data:
                     url: http://${NAS_IP}
                     icon: di:truenas
                   - title: Gatus
-                    url: https://status.${SECRET_DOMAIN}
+                    url: http://gatus.observability.svc.cluster.local
                     icon: di:gatus
 
           # Col 2 : search + services + reddit
@@ -639,7 +639,7 @@ data:
                         url: https://prometheus.${SECRET_DOMAIN}/-/healthy
                         icon: di:prometheus
                       - title: Gatus
-                        url: https://gatus.${SECRET_DOMAIN}/api/v1/endpoints/statuses
+                        url: http://gatus.observability.svc.cluster.local
                         icon: di:gatus
                       - title: TrueNAS
                         url: http://${NAS_IP}
@@ -764,7 +764,7 @@ data:
                 allow-insecure-html: true
                 cache: 30s
                 update-interval: 30s
-                url: "http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090/api/v1/query?query=(kube_pod_container_status_restarts_total>5)+or+(kube_pod_status_phase%7Bphase=~%22Pending%7CFailed%7CUnknown%22%7D==1)+or+(kube_pod_container_status_waiting_reason%7Breason=%22CrashLoopBackOff%22%7D==1)"
+                url: "http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090/api/v1/query?query=(sum+by+(namespace,pod)+(increase(kube_pod_container_status_restarts_total%5B1h%5D))+>+1)+or+(kube_pod_status_phase%7Bphase=~%22Pending%7CFailed%7CUnknown%22%7D==1)+or+(kube_pod_container_status_waiting_reason%7Breason=%22CrashLoopBackOff%22%7D==1)"
                 template: |
                   {{$results := .JSON.Array "data.result"}}
                   {{if eq (len $results) 0}}
@@ -785,7 +785,7 @@ data:
                 title: Gatus (santé globale)
                 sites:
                   - title: Tous les endpoints
-                    url: https://gatus.${SECRET_DOMAIN}/api/v1/endpoints/statuses
+                    url: http://gatus.observability.svc.cluster.local
                     icon: di:gatus
 
               - type: bookmarks


### PR DESCRIPTION
## Summary
Follow-up fixes after #179 based on screenshot review:

- **Gatus still 404'd** despite the URL fix in #179. Root cause: `gatus.kryzql.space` resolves to `192.168.42.110` (envoy-internal) via ExternalDNS, but the Gatus HTTPRoute is bound to `envoy-external`. Switching to the in-cluster service URL `http://gatus.observability.svc.cluster.local` bypasses the gateway mismatch.
- **K8s pod issues** widget showed ~15 pods because most pods accumulated 8+ restarts after a recent cluster reboot. Replaced cumulative `> 5` with `increase([1h]) > 1` to catch only actively-crashing pods.
- Patched `observability/gatus` CNP to allow `selfhosted/dynacat` ingress (mirrors existing prometheus entry).

3 files changed (Gatus URL fix applied in 3 places: home Infra widget, stats Infra subgroup, stats "santé globale" widget).

## Test plan
- [ ] flux-local CI green
- [ ] After merge: Gatus shows ✅ in both Infra subgroups + "santé globale" widget
- [ ] K8s pod issues shows only genuinely unhealthy pods (likely just romm with 413 restarts, or empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)