### PR TITLE
fix(dynacat): split Gatus url/check-url (public link + internal probe)

### DIFF
--- a/kubernetes/apps/selfhosted/dynacat/app/configmap.yaml
+++ b/kubernetes/apps/selfhosted/dynacat/app/configmap.yaml
@@ -46,7 +46,8 @@ data:
                     url: http://${NAS_IP}
                     icon: di:truenas
                   - title: Gatus
-                    url: http://gatus.observability.svc.cluster.local
+                    url: https://status.${SECRET_DOMAIN}
+                    check-url: http://gatus.observability.svc.cluster.local
                     icon: di:gatus
 
           # Col 2 : search + services + reddit
@@ -639,7 +640,8 @@ data:
                         url: https://prometheus.${SECRET_DOMAIN}/-/healthy
                         icon: di:prometheus
                       - title: Gatus
-                        url: http://gatus.observability.svc.cluster.local
+                        url: https://status.${SECRET_DOMAIN}
+                        check-url: http://gatus.observability.svc.cluster.local
                         icon: di:gatus
                       - title: TrueNAS
                         url: http://${NAS_IP}
@@ -785,7 +787,8 @@ data:
                 title: Gatus (santé globale)
                 sites:
                   - title: Tous les endpoints
-                    url: http://gatus.observability.svc.cluster.local
+                    url: https://status.${SECRET_DOMAIN}
+                    check-url: http://gatus.observability.svc.cluster.local
                     icon: di:gatus
 
               - type: bookmarks


### PR DESCRIPTION
## Summary
Follow-up to #180. Dynacat's monitor widget supports `check-url` as a separate health probe target. Restore public Gatus URL (https://status.${SECRET_DOMAIN}) for click action while keeping cluster-internal URL (http://gatus.observability.svc.cluster.local) as the probe. UX: clicking the widget now lands the user on the Gatus UI as expected.

## Test plan
- [ ] flux-local CI green
- [ ] After merge: Gatus widget still shows ✅ (probe via internal URL)
- [ ] Clicking the Gatus widget opens https://status.${SECRET_DOMAIN} in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)