### PR TITLE
fix(renovate): drop weekend-only schedule, run continuously

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -20,7 +20,6 @@
   ],
   dependencyDashboard: true,
   dependencyDashboardTitle: "Renovate Dashboard :robot:",
-  schedule: ["every weekend"],
   ignorePaths: ["**/*.sops.*"],
   flux: {
     managerFilePatterns: ["/(^|/)kubernetes/.+\\.ya?ml(?:\\.j2)?$/"],


### PR DESCRIPTION
Renovate was scheduled to run only Sat-Sun (`schedule: ["every weekend"]`), accumulating mid-week releases until the next weekend. Removed the schedule so the workflow CRON (hourly) is the only throttle. AutoMerge rules + groups still bound the PR volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)