### PR TITLE
fix(renovate): disable python/cpython lookup (cascades to false repo-changed)

### DIFF
--- a/.renovate/overrides.json5
+++ b/.renovate/overrides.json5
@@ -19,5 +19,10 @@
       matchPackageNames: ["nextcloud"],
       separateMultipleMajor: true,
     },
+    {
+      description: "Disable python/cpython lookup — GraphQL empty-response bug aborts the run with false-positive 'repository-changed'. Python version pinned by mise anyway.",
+      matchPackageNames: ["python/cpython", "python"],
+      enabled: false,
+    },
   ],
 }


### PR DESCRIPTION
Renovate runs were all aborting in the lookup phase on `python/cpython` GraphQL empty-response → false-positive "Repository has changed during renovation" abort 35s later. 0 PRs created since 00:04 UTC. Python version is pinned by mise so we don't actually need this lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)