### PR TITLE
fix: recover Ceph storage + internal DNS after stalled rook/Talos upgrades

### DIFF
--- a/kubernetes/apps/kube-system/intel-gpu-resource-driver/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/intel-gpu-resource-driver/app/helmrelease.yaml
@@ -13,3 +13,11 @@ spec:
     cdi:
       staticPath: /var/cdi/static
       dynamicPath: /var/cdi/dynamic
+    kubeletPlugin:
+      # xpumd (Intel XPU Manager) is not deployed on these Talos nodes, so the
+      # default health monitoring (-m flag) panics: "failed to connect to xpumd".
+      # Disable it and let the driver read hardware details directly (needs
+      # privileged) instead of via xpumd.
+      healthMonitoring:
+        enabled: false
+      privileged: true

--- a/kubernetes/apps/network/opnsense-dns/app/cronjob.yaml
+++ b/kubernetes/apps/network/opnsense-dns/app/cronjob.yaml
@@ -19,7 +19,7 @@ data:
     import os, json, sys, ssl, base64
     import urllib.request
 
-    HOST = "https://opnsense.internal"
+    HOST = "https://192.168.42.1"  # IP, not a name — avoids circular DNS dependency
     DOMAIN = "${SECRET_DOMAIN}"
     PREFIX = "k8s.main.cname-"
     KEY = os.environ["OPNSENSE_API_KEY"]

--- a/kubernetes/apps/network/opnsense-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/opnsense-dns/app/helmrelease.yaml
@@ -18,8 +18,12 @@ spec:
           repository: ghcr.io/crutonjohn/external-dns-opnsense-webhook
           tag: v1.0.0
         env:
+          # NOTE: must be the OPNsense IP, NOT a hostname. Using a name here
+          # (e.g. opnsense.internal) creates a circular dependency — ExternalDNS
+          # cannot resolve its own target once internal DNS is disrupted, and can
+          # then never repair the records. Always point the DNS updater at an IP.
           - name: OPNSENSE_HOST
-            value: https://opnsense.internal
+            value: https://192.168.42.1
           - name: OPNSENSE_API_KEY
             valueFrom:
               secretKeyRef:

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/csi-plugin-rbac.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/csi-plugin-rbac.yaml
@@ -1,0 +1,138 @@
+---
+# Standard ceph-csi plugin RBAC. The rook v1.20 / ceph-csi-operator migration
+# references per-driver ServiceAccounts (rbd/cephfs nodeplugin + ctrlplugin) but
+# does NOT provision their SAs or RBAC — they must be supplied here. Without this,
+# nodeplugin pods crashloop ("cannot get nodes") and the csi-attacher/provisioner
+# sidecars can't attach volumes, leaving every Ceph-RBD pod stuck ContainerCreating.
+apiVersion: v1
+kind: ServiceAccount
+metadata: { name: rbd-nodeplugin-sa, namespace: rook-ceph }
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata: { name: rbd-ctrlplugin-sa, namespace: rook-ceph }
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata: { name: cephfs-nodeplugin-sa, namespace: rook-ceph }
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata: { name: cephfs-ctrlplugin-sa, namespace: rook-ceph }
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: { name: rook-csi-nodeplugin }
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts/token"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["list", "get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: { name: rook-csi-ctrlplugin }
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts/token"]
+    verbs: ["create"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots", "volumesnapshotcontents", "volumesnapshotclasses"]
+    verbs: ["get", "list", "watch", "update", "patch", "create", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status", "volumesnapshots/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattributesclasses"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata: { name: rook-csi-nodeplugin }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: rook-csi-nodeplugin }
+subjects:
+  - { kind: ServiceAccount, name: rbd-nodeplugin-sa, namespace: rook-ceph }
+  - { kind: ServiceAccount, name: cephfs-nodeplugin-sa, namespace: rook-ceph }
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata: { name: rook-csi-ctrlplugin }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: rook-csi-ctrlplugin }
+subjects:
+  - { kind: ServiceAccount, name: rbd-ctrlplugin-sa, namespace: rook-ceph }
+  - { kind: ServiceAccount, name: cephfs-ctrlplugin-sa, namespace: rook-ceph }
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata: { name: rook-csi-ctrlplugin-leader, namespace: rook-ceph }
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata: { name: rook-csi-ctrlplugin-leader, namespace: rook-ceph }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: Role, name: rook-csi-ctrlplugin-leader }
+subjects:
+  - { kind: ServiceAccount, name: rbd-ctrlplugin-sa, namespace: rook-ceph }
+  - { kind: ServiceAccount, name: cephfs-ctrlplugin-sa, namespace: rook-ceph }

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -32,6 +32,13 @@ spec:
           - name: envoy-internal
             namespace: network
     cephClusterSpec:
+      # Pin the Ceph image explicitly. The on-disk mon/osd store format is
+      # already v20 (Tentacle); relying on the chart default let a chart bump
+      # try to downgrade to v19.2.3 (Squid), which mons refuse to start on
+      # ("unsupported features: incompat={17=tentacle ondisk layout}") and
+      # broke quorum. Never let the Ceph version float for a live cluster.
+      cephVersion:
+        image: quay.io/ceph/ceph:v20.2.1
       cephConfig:
         global:
           bdev_enable_discard: "true" # quote

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./csi-plugin-rbac.yaml

--- a/kubernetes/apps/selfhosted/immich/app/cluster.yaml
+++ b/kubernetes/apps/selfhosted/immich/app/cluster.yaml
@@ -10,7 +10,11 @@ spec:
   imageName: ghcr.io/cloudnative-pg/postgresql:16
   storage:
     storageClass: ceph-block
-    size: 5Gi
+    # 20Gi (was 5Gi): the combined data+WAL volume filled during the 2026-06
+    # Ceph outage when WAL archiving stalled, and CNPG halts ("Not enough disk
+    # space") until the PVC is enlarged. Headroom to ride out future archiving
+    # outages without wedging the primary.
+    size: 20Gi
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
## Incident summary
A single cascade (root: the 2026-06-01/02 Renovate mass-merge that started a Talos **and** a rook v1.19.6→v1.20.0 upgrade, which stalled when node01 got cordoned and never uncordoned) took down Ceph quorum, the CSI layer (22+ pods stuck `ContainerCreating`), and internal DNS resolution.

`montel` losing access to navidrome/obsidian was a **symptom**: both apps were healthy, but their Ceph-RBD pods couldn't attach volumes (CSI down) → 503.

## What this PR makes durable (already applied live during recovery)

### rook-ceph
- **Pin `cephVersion.image: v20.2.1`** — mon/osd on-disk store is already v20 (Tentacle); the chart default let the rolled-back cluster chart try to downgrade to v19.2.3 (Squid), which mons refuse (`incompat={17=tentacle ondisk layout}`) → quorum loss.
- **`csi-plugin-rbac.yaml`** — the v1.20 ceph-csi-operator references per-driver SAs (`rbd/cephfs-nodeplugin-sa`, `*-ctrlplugin-sa`) but provisions neither the SAs nor their RBAC. Adds the standard ceph-csi ServiceAccounts + ClusterRoles/bindings. Without it: `rbd-nodeplugin-sa cannot get nodes`, attacher failures, all RBD pods stuck.

### opnsense-dns
- **Point ExternalDNS + orphan-cleanup cronjob at `192.168.42.1`** instead of `opnsense.internal`. The hostname created a circular dependency — ExternalDNS couldn't resolve its own target once internal DNS broke, so it could never repair the records (10k+ consecutive soft errors).

## Live actions NOT in this PR (operational, already done)
- `kubectl uncordon node01` (twice — stuck cordoned after Talos upgrades)
- Removed stale `mon-d` (8d out of quorum, tentacle store) → operator recreated `mon-e`
- Restored mon quorum on v20.2.1

## Post-merge
Resume the still-suspended Flux Kustomization: `flux resume ks opnsense-dns -n network` (kept suspended so it doesn't revert the live IP fix before this merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)