### PR TITLE
fix(rook-ceph): pin ceph image via top-level cephImage

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -10,6 +10,13 @@ spec:
     name: rook-ceph-cluster
   interval: 1h
   values:
+    # Pin the Ceph image via the chart's documented top-level value. Do NOT put
+    # a cephVersion block inside cephClusterSpec — the chart renders cephVersion
+    # there too, producing a duplicate-key error. The on-disk mon/osd store is
+    # v20 (Tentacle) and cannot be downgraded, so never let the version float.
+    cephImage:
+      repository: quay.io/ceph/ceph
+      tag: v20.2.1
     monitoring:
       enabled: true
       createPrometheusRules: true
@@ -32,13 +39,6 @@ spec:
           - name: envoy-internal
             namespace: network
     cephClusterSpec:
-      # Pin the Ceph image explicitly. The on-disk mon/osd store format is
-      # already v20 (Tentacle); relying on the chart default let a chart bump
-      # try to downgrade to v19.2.3 (Squid), which mons refuse to start on
-      # ("unsupported features: incompat={17=tentacle ondisk layout}") and
-      # broke quorum. Never let the Ceph version float for a live cluster.
-      cephVersion:
-        image: quay.io/ceph/ceph:v20.2.1
       cephConfig:
         global:
           bdev_enable_discard: "true" # quote


### PR DESCRIPTION
Repairs the rook-ceph-cluster HelmRelease reconcile that broke after #276: `cephClusterSpec.cephVersion` causes a duplicate-key render error; the chart's top-level `cephImage` (repository+tag) is the documented way to pin. Cluster runtime was unaffected (HEALTH_OK); this only fixes Flux reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)