### PR TITLE
fix(cilium): L2-announce LoadBalancer IPs for same-subnet LAN reachability

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -48,7 +48,11 @@ spec:
     kubeProxyReplacement: true
     kubeProxyReplacementHealthzBindAddr: 0.0.0.0:10256
     l2announcements:
-      enabled: false
+      # Enabled so gateway LB IPs (.110/.120) are answered via ARP directly by
+      # the nodes. They share the /24 with LAN clients, where BGP-only + OPNsense
+      # proxy-ARP caused asymmetric routing (worsened by DSR) and intermittent
+      # connectivity. See l2.yaml for the announcement policy.
+      enabled: true
     loadBalancer:
       acceleration: best-effort
       algorithm: maglev

--- a/kubernetes/apps/kube-system/cilium/config/kustomization.yaml
+++ b/kubernetes/apps/kube-system/cilium/config/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./l3.yaml
   - ./pool.yaml
+  - ./l2.yaml

--- a/kubernetes/apps/kube-system/cilium/config/l2.yaml
+++ b/kubernetes/apps/kube-system/cilium/config/l2.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: https://k8s-schemas.bjw-s.dev/cilium.io/ciliuml2announcementpolicy_v2alpha1.json
+apiVersion: cilium.io/v2alpha1
+kind: CiliumL2AnnouncementPolicy
+metadata:
+  name: l2-loadbalancer
+spec:
+  # Announce all LoadBalancer service IPs (gateways .110/.120 + services pool)
+  # via ARP from the nodes. These IPs share the node /24 with LAN clients, so
+  # same-subnet clients must reach them at L2 directly — BGP-only relied on
+  # OPNsense proxy-ARP + routing, which was asymmetric (DSR) and flaky.
+  loadBalancerIPs: true
+  interfaces:
+    - ^enp.*
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/os: linux


### PR DESCRIPTION
## Problem
Internal apps (navidrome via Feishin, obsidian, …) were intermittently unreachable from LAN clients ("server unavailable", ~7/10 success). Root cause: the gateway LB IPs (`.110`/`.120`) are in the same `/24` as LAN clients but were advertised **only via BGP** to OPNsense. Same-subnet clients reached them via OPNsense **proxy-ARP + routing** — an **asymmetric path** (made worse by Cilium **DSR** mode + `externalTrafficPolicy: Local` ECMP across 2 nodes), causing dropped connections.

## Fix
- `l2announcements.enabled: true`
- `CiliumL2AnnouncementPolicy` (`l2.yaml`) announcing all LB IPs via ARP on the `enp*` LAN interface.

Now the nodes answer ARP for the LB IPs directly (node MAC) → symmetric L2 path, no OPNsense routing dependency.

## Verification
From a LAN host (192.168.42.40): **20/20** requests to `navidrome.kryzql.space` succeeded (was ~7/10), ARP for `.110` stably owned by node03, OPNsense did not reclaim it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)