### PR TITLE
revert: navidrome back to original (pre-saga state)

### DIFF
--- a/kubernetes/apps/media/navidrome/ks.yaml
+++ b/kubernetes/apps/media/navidrome/ks.yaml
@@ -19,22 +19,6 @@ spec:
 
   interval: 1h
   path: "./kubernetes/apps/media/navidrome/app"
-  patches:
-    # Keep navidrome always reachable. The nfs-scaler component scales it to 0
-    # when the NAS NFS probe (192.168.42.44:2049) goes inactive, which makes the
-    # gateway return HTTP 503 to clients (Feishin "network error"). Pin
-    # minReplicaCount to 1 so the app stays up. This touches ONLY navidrome's
-    # KEDA ScaledObject — no networking / gateway changes.
-    - patch: |
-        apiVersion: keda.sh/v1alpha1
-        kind: ScaledObject
-        metadata:
-          name: navidrome
-        spec:
-          minReplicaCount: 1
-      target:
-        kind: ScaledObject
-        name: navidrome
   postBuild:
     substitute:
       APP: navidrome

--- a/kubernetes/apps/media/navidrome/ks.yaml
+++ b/kubernetes/apps/media/navidrome/ks.yaml
@@ -19,15 +19,25 @@ spec:
 
   interval: 1h
   path: "./kubernetes/apps/media/navidrome/app"
+  patches:
+    # Keep navidrome always reachable. The nfs-scaler component scales it to 0
+    # when the NAS NFS probe (192.168.42.44:2049) goes inactive, which makes the
+    # gateway return HTTP 503 to clients (Feishin "network error"). Pin
+    # minReplicaCount to 1 so the app stays up. This touches ONLY navidrome's
+    # KEDA ScaledObject — no networking / gateway changes.
+    - patch: |
+        apiVersion: keda.sh/v1alpha1
+        kind: ScaledObject
+        metadata:
+          name: navidrome
+        spec:
+          minReplicaCount: 1
+      target:
+        kind: ScaledObject
+        name: navidrome
   postBuild:
     substitute:
       APP: navidrome
-      # Keep navidrome always reachable. The nfs-scaler scales it to 0 when the
-      # NAS NFS probe (192.168.42.44:2049) is inactive, which makes the gateway
-      # return HTTP 503 to clients (Feishin "network error"). Pin the scaler's
-      # floor to 1 so it stays up. Touches ONLY navidrome's KEDA scaler — no
-      # networking / gateway changes.
-      MIN_REPLICAS: "1"
       VOLSYNC_CLAIM: navidrome
       VOLSYNC_SCHEDULE: "30 3 * * *"
   prune: true

--- a/kubernetes/components/nfs-scaler/scaledobject.yaml
+++ b/kubernetes/components/nfs-scaler/scaledobject.yaml
@@ -11,7 +11,7 @@ spec:
   fallback:
     failureThreshold: 3
     replicas: 1
-  minReplicaCount: ${MIN_REPLICAS:=0}
+  minReplicaCount: 0
   maxReplicaCount: 1
   scaleTargetRef:
     apiVersion: apps/v1


### PR DESCRIPTION
Reverts #285 and #286. Restores navidrome and the nfs-scaler component to exactly the state before the navidrome/gateway troubleshooting. Combined with #284 (L2 already reverted), everything is back to comme avant. 🤖 Generated with [Claude Code](https://claude.com/claude-code)