### PR TITLE
fix(dns): mask internal IPs + cloudflare-proxied=false per record

### DIFF
--- a/kubernetes/apps/network/cloudflare-dns/app/dnsendpoint.yaml
+++ b/kubernetes/apps/network/cloudflare-dns/app/dnsendpoint.yaml
@@ -4,107 +4,197 @@ apiVersion: externaldns.k8s.io/v1alpha1
 kind: DNSEndpoint
 metadata:
   name: internal-apps-lan
-  annotations:
-    # Internal apps live behind the internal gateway (192.168.42.110). Publish
-    # public A records so devices on the Tailscale VPN (whatever DNS they use)
-    # resolve them and reach .110 via the approved 192.168.42.0/24 subnet route.
-    # DNS-only (proxied=false) is REQUIRED: Cloudflare cannot proxy a private IP.
-    external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
 spec:
   endpoints:
     - dnsName: "ai.${SECRET_DOMAIN}"
       recordType: A
-      targets: ["192.168.42.110"]
+      targets: ["${CLUSTER_GATEWAY_INTERNAL_IP}"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
     - dnsName: "alertmanager.${SECRET_DOMAIN}"
       recordType: A
-      targets: ["192.168.42.110"]
+      targets: ["${CLUSTER_GATEWAY_INTERNAL_IP}"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
     - dnsName: "atuin.${SECRET_DOMAIN}"
       recordType: A
-      targets: ["192.168.42.110"]
+      targets: ["${CLUSTER_GATEWAY_INTERNAL_IP}"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
     - dnsName: "audiobookshelf.${SECRET_DOMAIN}"
       recordType: A
-      targets: ["192.168.42.110"]
+      targets: ["${CLUSTER_GATEWAY_INTERNAL_IP}"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
     - dnsName: "bazarr.${SECRET_DOMAIN}"
       recordType: A
-      targets: ["192.168.42.110"]
+      targets: ["${CLUSTER_GATEWAY_INTERNAL_IP}"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
     - dnsName: "budget.${SECRET_DOMAIN}"
       recordType: A
-      targets: ["192.168.42.110"]
+      targets: ["${CLUSTER_GATEWAY_INTERNAL_IP}"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
     - dnsName: "crafty.${SECRET_DOMAIN}"
       recordType: A
-      targets: ["192.168.42.110"]
+      targets: ["${CLUSTER_GATEWAY_INTERNAL_IP}"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
     - dnsName: "emby.${SECRET_DOMAIN}"
       recordType: A
-      targets: ["192.168.42.110"]
+      targets: ["${CLUSTER_GATEWAY_INTERNAL_IP}"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
     - dnsName: "fitness.${SECRET_DOMAIN}"
       recordType: A
-      targets: ["192.168.42.110"]
+      targets: ["${CLUSTER_GATEWAY_INTERNAL_IP}"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
     - dnsName: "grafana.${SECRET_DOMAIN}"
       recordType: A
-      targets: ["192.168.42.110"]
+      targets: ["${CLUSTER_GATEWAY_INTERNAL_IP}"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
     - dnsName: "home.${SECRET_DOMAIN}"
       recordType: A
-      targets: ["192.168.42.110"]
+      targets: ["${CLUSTER_GATEWAY_INTERNAL_IP}"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
     - dnsName: "immich.${SECRET_DOMAIN}"
       recordType: A
-      targets: ["192.168.42.110"]
+      targets: ["${CLUSTER_GATEWAY_INTERNAL_IP}"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
     - dnsName: "it-tools.${SECRET_DOMAIN}"
       recordType: A
-      targets: ["192.168.42.110"]
+      targets: ["${CLUSTER_GATEWAY_INTERNAL_IP}"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
     - dnsName: "kopia.${SECRET_DOMAIN}"
       recordType: A
-      targets: ["192.168.42.110"]
+      targets: ["${CLUSTER_GATEWAY_INTERNAL_IP}"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
     - dnsName: "lidarr.${SECRET_DOMAIN}"
       recordType: A
-      targets: ["192.168.42.110"]
+      targets: ["${CLUSTER_GATEWAY_INTERNAL_IP}"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
     - dnsName: "navidrome.${SECRET_DOMAIN}"
       recordType: A
-      targets: ["192.168.42.110"]
+      targets: ["${CLUSTER_GATEWAY_INTERNAL_IP}"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
     - dnsName: "nextcloud.${SECRET_DOMAIN}"
       recordType: A
-      targets: ["192.168.42.110"]
+      targets: ["${CLUSTER_GATEWAY_INTERNAL_IP}"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
     - dnsName: "obsidian.${SECRET_DOMAIN}"
       recordType: A
-      targets: ["192.168.42.110"]
+      targets: ["${CLUSTER_GATEWAY_INTERNAL_IP}"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
     - dnsName: "paperless.${SECRET_DOMAIN}"
       recordType: A
-      targets: ["192.168.42.110"]
+      targets: ["${CLUSTER_GATEWAY_INTERNAL_IP}"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
     - dnsName: "pdf.${SECRET_DOMAIN}"
       recordType: A
-      targets: ["192.168.42.110"]
+      targets: ["${CLUSTER_GATEWAY_INTERNAL_IP}"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
     - dnsName: "prometheus.${SECRET_DOMAIN}"
       recordType: A
-      targets: ["192.168.42.110"]
+      targets: ["${CLUSTER_GATEWAY_INTERNAL_IP}"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
     - dnsName: "prowlarr.${SECRET_DOMAIN}"
       recordType: A
-      targets: ["192.168.42.110"]
+      targets: ["${CLUSTER_GATEWAY_INTERNAL_IP}"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
     - dnsName: "qbittorrent.${SECRET_DOMAIN}"
       recordType: A
-      targets: ["192.168.42.110"]
+      targets: ["${CLUSTER_GATEWAY_INTERNAL_IP}"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
     - dnsName: "radarr.${SECRET_DOMAIN}"
       recordType: A
-      targets: ["192.168.42.110"]
+      targets: ["${CLUSTER_GATEWAY_INTERNAL_IP}"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
     - dnsName: "readarr.${SECRET_DOMAIN}"
       recordType: A
-      targets: ["192.168.42.110"]
+      targets: ["${CLUSTER_GATEWAY_INTERNAL_IP}"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
     - dnsName: "romm.${SECRET_DOMAIN}"
       recordType: A
-      targets: ["192.168.42.110"]
+      targets: ["${CLUSTER_GATEWAY_INTERNAL_IP}"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
     - dnsName: "rook.${SECRET_DOMAIN}"
       recordType: A
-      targets: ["192.168.42.110"]
+      targets: ["${CLUSTER_GATEWAY_INTERNAL_IP}"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
     - dnsName: "sabnzbd.${SECRET_DOMAIN}"
       recordType: A
-      targets: ["192.168.42.110"]
+      targets: ["${CLUSTER_GATEWAY_INTERNAL_IP}"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
     - dnsName: "seerr.${SECRET_DOMAIN}"
       recordType: A
-      targets: ["192.168.42.110"]
+      targets: ["${CLUSTER_GATEWAY_INTERNAL_IP}"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
     - dnsName: "sonarr.${SECRET_DOMAIN}"
       recordType: A
-      targets: ["192.168.42.110"]
+      targets: ["${CLUSTER_GATEWAY_INTERNAL_IP}"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
     - dnsName: "tandoor.${SECRET_DOMAIN}"
       recordType: A
-      targets: ["192.168.42.110"]
+      targets: ["${CLUSTER_GATEWAY_INTERNAL_IP}"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
     - dnsName: "victoria-logs.${SECRET_DOMAIN}"
       recordType: A
-      targets: ["192.168.42.110"]
+      targets: ["${CLUSTER_GATEWAY_INTERNAL_IP}"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"

--- a/kubernetes/apps/network/opnsense-dns/app/cronjob.yaml
+++ b/kubernetes/apps/network/opnsense-dns/app/cronjob.yaml
@@ -19,7 +19,7 @@ data:
     import os, json, sys, ssl, base64
     import urllib.request
 
-    HOST = "https://192.168.42.1"  # IP, not a name — avoids circular DNS dependency
+    HOST = "https://${BGP_ROUTER_IP}"  # IP, not a name — avoids circular DNS dependency
     DOMAIN = "${SECRET_DOMAIN}"
     PREFIX = "k8s.main.cname-"
     KEY = os.environ["OPNSENSE_API_KEY"]

--- a/kubernetes/apps/network/opnsense-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/opnsense-dns/app/helmrelease.yaml
@@ -23,7 +23,7 @@ spec:
           # cannot resolve its own target once internal DNS is disrupted, and can
           # then never repair the records. Always point the DNS updater at an IP.
           - name: OPNSENSE_HOST
-            value: https://192.168.42.1
+            value: https://${BGP_ROUTER_IP}
           - name: OPNSENSE_API_KEY
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
Follow-up to #288: replace hardcoded private IPs with the SOPS-encrypted ${CLUSTER_GATEWAY_INTERNAL_IP}/${BGP_ROUTER_IP} vars, and set cloudflare-proxied=false per DNSEndpoint record (the metadata annotation is ignored for CRDs → Cloudflare rejected the proxied private-IP A records). 🤖 Generated with [Claude Code](https://claude.com/claude-code)