### PR TITLE
fix(dynacat): reliable Arr monitor status + Tandoor label

### DIFF
--- a/kubernetes/apps/selfhosted/dynacat/app/configmap.yaml
+++ b/kubernetes/apps/selfhosted/dynacat/app/configmap.yaml
@@ -59,21 +59,27 @@ data:
                     sites:
                       - title: Radarr
                         url: https://radarr.${SECRET_DOMAIN}
+                        check-url: http://radarr.downloads.svc.cluster.local:7878/ping
                         icon: di:radarr
                       - title: Sonarr
                         url: https://sonarr.${SECRET_DOMAIN}
+                        check-url: http://sonarr.downloads.svc.cluster.local:8989/ping
                         icon: di:sonarr
                       - title: Bazarr
                         url: https://bazarr.${SECRET_DOMAIN}
+                        check-url: http://bazarr.downloads.svc.cluster.local:80/ping
                         icon: di:bazarr
                       - title: Prowlarr
                         url: https://prowlarr.${SECRET_DOMAIN}
+                        check-url: http://prowlarr.downloads.svc.cluster.local:80/ping
                         icon: di:prowlarr
                       - title: Sabnzbd
                         url: https://sabnzbd.${SECRET_DOMAIN}
+                        check-url: http://sabnzbd.downloads.svc.cluster.local:80
                         icon: di:sabnzbd
                       - title: qBittorrent
                         url: https://qbittorrent.${SECRET_DOMAIN}
+                        check-url: http://qbittorrent.downloads.svc.cluster.local:8080
                         icon: di:qbittorrent
                   - type: monitor
                     title: Other
@@ -81,7 +87,7 @@ data:
                       - title: Paperless
                         url: https://paperless.${SECRET_DOMAIN}
                         icon: di:paperless-ngx
-                      - title: Mealie
+                      - title: Tandoor
                         url: https://tandoor.${SECRET_DOMAIN}
                         icon: si:tandoorrecipes
                       - title: Nextcloud
@@ -607,21 +613,27 @@ data:
                     sites:
                       - title: Radarr
                         url: https://radarr.${SECRET_DOMAIN}
+                        check-url: http://radarr.downloads.svc.cluster.local:7878/ping
                         icon: di:radarr
                       - title: Sonarr
                         url: https://sonarr.${SECRET_DOMAIN}
+                        check-url: http://sonarr.downloads.svc.cluster.local:8989/ping
                         icon: di:sonarr
                       - title: Bazarr
                         url: https://bazarr.${SECRET_DOMAIN}
+                        check-url: http://bazarr.downloads.svc.cluster.local:80/ping
                         icon: di:bazarr
                       - title: Prowlarr
                         url: https://prowlarr.${SECRET_DOMAIN}
+                        check-url: http://prowlarr.downloads.svc.cluster.local:80/ping
                         icon: di:prowlarr
                       - title: Sabnzbd
                         url: https://sabnzbd.${SECRET_DOMAIN}
+                        check-url: http://sabnzbd.downloads.svc.cluster.local:80
                         icon: di:sabnzbd
                       - title: qBittorrent
                         url: https://qbittorrent.${SECRET_DOMAIN}
+                        check-url: http://qbittorrent.downloads.svc.cluster.local:8080
                         icon: di:qbittorrent
                   - type: monitor
                     title: Selfhosted


### PR DESCRIPTION
## Quoi

Deux corrections de fiabilité sur la homepage dynacat (direction « fiabilité / correction »).

### 1. Statut des monitors « Arr » faux
Les 6 services Arr (Radarr/Sonarr/Bazarr/Prowlarr/Sabnzbd/qBittorrent), sur la page **home** et **stats**, n'étaient sondés que sur leur URL publique `https://*.${SECRET_DOMAIN}`. Le widget `monitor` suit la redirection gateway/auth → il affichait **UP** dès que la gateway interne répondait, même quand l'app derrière était morte ou scale-to-zero (503).

→ Ajout d'un `check-url` interne (DNS de service, **aucune IP en dur**) par app, comme le pattern déjà utilisé par les monitors « Media ». Les 6 renvoient HTTP 200 depuis le pod dynacat.

### 2. Mauvais libellé
« Mealie » pointait sur l'URL/icône Tandoor (Mealie n'existe plus) → renommé en « Tandoor ».

## Hors scope (volontairement)
- Timeouts GitHub du widget « Nouvelles versions » : cosmétiques (cache 1h sert le stale, egress OK), pas une panne.
- Requête Prometheus « Infra » monolithique : fonctionne, pas un bug → pas touché.

🤖 Generated with [Claude Code](https://claude.com/claude-code)