### PR TITLE
fix(talos): tune kubelet image GC to relieve OS disk pressure

### DIFF
--- a/talos/patches/global/machine-kubelet.yaml
+++ b/talos/patches/global/machine-kubelet.yaml
@@ -4,6 +4,12 @@ machine:
     disableManifestsDirectory: true
     extraConfig:
       serializeImagePulls: false
+      # Reclaim unused container images before the OS disk fills up. Defaults
+      # (85/80) only kick in very late; with frequent Renovate image churn the
+      # 256G OS disk crept to 73% and tripped Ceph's mon_data_avail_warn. 70/55
+      # makes kubelet prune unused images continuously, well clear of the warn.
+      imageGCHighThresholdPercent: 70
+      imageGCLowThresholdPercent: 55
     nodeIP:
       validSubnets:
         - 192.168.42.0/24


### PR DESCRIPTION
## Problème
Le disque OS (EPHEMERAL, 256 G) de chaque node grimpait — node02 à **73%** — ce qui déclenchait le `MON_DISK_LOW` / `mon_data_avail_warn` de Ceph (alerte sous 30% libre).

Le gros consommateur : le cache d'images **containerd** (~144 G : 105 G snapshots + 39 G blobs), local à chaque node par nature — il ne peut **pas** aller sur le SSD Ceph 1T (OSD brut, aucune partition libre). Les données applicatives (PVC) sont déjà sur Ceph.

## Cause racine
Le GC d'images de kubelet ne se déclenche qu'à 85% (défaut). En-dessous, les vieilles versions d'images (churn Renovate quasi quotidien) s'empilent : **730 images en cache sur node02 pour seulement 46 utilisées**.

## Fix
Abaisser les seuils dans le patch kubelet Talos :
```yaml
imageGCHighThresholdPercent: 70
imageGCLowThresholdPercent: 55
```

## Résultat (vérifié)
Appliqué sur les 3 nodes via `talosctl` (sans reboot, kubelet redémarre en place). Sur node02 :
- images : **730 → 138**
- disque : **73% → 21%** (~124 G récupérés)
- **Ceph : HEALTH_WARN → HEALTH_OK**
- aucun pod impacté (GC ne touche que les images inutilisées)

node01/node03 sous le seuil, protégés pour l'avenir (auto-purge à 70%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)