### PR TITLE
fix(network): pin cloudflared back to 2026.5.2 (token regression)

### DIFF
--- a/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
@@ -18,7 +18,11 @@ spec:
           app:
             image:
               repository: docker.io/cloudflare/cloudflared
-              tag: 2026.6.0
+              # Pinned: 2026.6.0 rejects the (valid) tunnel token with "Provided
+              # Tunnel token is not valid" and CrashLoops, while 2026.5.2 runs the
+              # exact same secret fine — upstream token-validation regression.
+              # Re-test before taking the Renovate bump past 2026.5.2 again.
+              tag: 2026.5.2
             env:
               NO_AUTOUPDATE: true
               TUNNEL_METRICS: 0.0.0.0:8080


### PR DESCRIPTION
## Problème
La bump cloudflared 2026.5.2→2026.6.0 (#263, mergée dans le lot Renovate) fait **CrashLooper** `cloudflare-tunnel` :
```
Provided Tunnel token is not valid.
```
Le pod 2026.5.2 tourne pourtant avec **le même secret** sans souci → **régression de validation du token en amont** dans 2026.6.0.

## Impact
Aucune coupure : le rolling update a gardé l'ancien pod (2026.5.2) actif puisque le nouveau n'est jamais passé Ready. L'accès externe est resté up.

## Fix
Repin `2026.5.2` (known-good) + commentaire pour ne pas re-merger la bump aveuglément quand Renovate la re-proposera.

🤖 Generated with [Claude Code](https://claude.com/claude-code)