### PR TITLE
feat(app-template): pin SA token automount for tailscale + gatus (v5 prep)

### DIFF
--- a/kubernetes/apps/network/tailscale/app/helmrelease.yaml
+++ b/kubernetes/apps/network/tailscale/app/helmrelease.yaml
@@ -42,6 +42,10 @@ spec:
               limits:
                 memory: 512Mi
     defaultPodOptions:
+      # tailscale persists its node state in the tailscale-state Secret via the
+      # k8s API (TS_KUBE_SECRET + rbac.yaml). app-template v5 flips the SA token
+      # automount default to false, which would break that — keep it mounted.
+      automountServiceAccountToken: true
       securityContext:
         runAsNonRoot: false
         runAsUser: 0

--- a/kubernetes/apps/observability/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/gatus/app/helmrelease.yaml
@@ -82,6 +82,9 @@ spec:
               accessMode: ReadWriteOnce
               size: 5Gi
     defaultPodOptions:
+      # gatus has an explicit ServiceAccount + RoleBinding; preserve its SA token
+      # automount, which app-template v5 would otherwise default to false.
+      automountServiceAccountToken: true
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000


### PR DESCRIPTION
## Contexte
Prep pour la migration app-template 4.6.2→5.0.1 (#244). En v5, `defaultPodOptions.automountServiceAccountToken` passe à `false` par défaut.

## Pourquoi
Sur 36 apps app-template, **2 parlent à l'API k8s** et casseraient sans le token :
- **tailscale** — persiste son état dans le Secret `tailscale-state` via l'API (`TS_KUBE_SECRET` + `rbac.yaml`). Sans token → subnet router HS → accès VPN distant cassé.
- **gatus** — SA + RoleBinding explicites, on préserve par prudence.

## Fix
`automountServiceAccountToken: true` explicite sur ces 2 apps. **No-op en v4** (défaut déjà true), devient load-bearing quand #244 (v5) sera mergée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)