### PR TITLE
feat(app-template): canary echo + dynacat to v5.0.1

### DIFF
--- a/kubernetes/apps/network/echo/app/ocirepository.yaml
+++ b/kubernetes/apps/network/echo/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 4.6.2
+    tag: 5.0.1
   url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/selfhosted/dynacat/app/ocirepository.yaml
+++ b/kubernetes/apps/selfhosted/dynacat/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 4.6.2
+    tag: 5.0.1
   url: oci://ghcr.io/bjw-s-labs/helm/app-template


### PR DESCRIPTION
Canary de la migration app-template v5 (#244) sur 2 apps stateless non critiques (echo, dynacat) avant de dérouler les ~34 autres. Aucune des deux n'utilise le token SA → le changement d'automount v5 est sans effet pour elles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)