### PR TITLE
feat(postgres): safe bumps split from #246 (sparkyfitness 18.4 + pgdump 18)

### DIFF
--- a/kubernetes/apps/selfhosted/immich/app/pgdump.yaml
+++ b/kubernetes/apps/selfhosted/immich/app/pgdump.yaml
@@ -23,7 +23,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: pgdump
-              image: postgres:16-alpine
+              image: postgres:18-alpine
               command: ["/bin/sh", "-c"]
               args:
                 - |

--- a/kubernetes/apps/selfhosted/nextcloud/app/pgdump.yaml
+++ b/kubernetes/apps/selfhosted/nextcloud/app/pgdump.yaml
@@ -23,7 +23,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: pgdump
-              image: postgres:16-alpine
+              image: postgres:18-alpine
               command: ["/bin/sh", "-c"]
               args:
                 - |

--- a/kubernetes/apps/selfhosted/sparkyfitness/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/sparkyfitness/app/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
           postgres:
             image:
               repository: postgres
-              tag: "18.3-alpine"
+              tag: "18.4-alpine"
             env:
               POSTGRES_USER: sparky
               POSTGRES_DB: sparkyfitness


### PR DESCRIPTION
Split des parties sûres de #246. tandoor 16→18 (majeur, migration PGDATA) traité à part. Voir le commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)