### PR TITLE
feat(tandoor): migrate postgres 16 → 18

### DIFF
--- a/kubernetes/apps/default/tandoor/app/helmrelease.yaml
+++ b/kubernetes/apps/default/tandoor/app/helmrelease.yaml
@@ -75,7 +75,10 @@ spec:
           postgres:
             image:
               repository: postgres
-              tag: "16"
+              # Major-upgraded 16 → 18 via offline pg_dump → wipe PGDATA →
+              # fresh initdb → pg_restore (plain container can't cross PG majors
+              # in place). Data verified (99 tables, 103 recipes) post-restore.
+              tag: "18"
             env:
               POSTGRES_USER: tandoor
               POSTGRES_DB: tandoor


### PR DESCRIPTION
Dernier reliquat de #246. Migration offline du conteneur postgres brut de tandoor : pg_dump → wipe PGDATA → initdb 18 → pg_restore. Intégrité vérifiée (99 tables, 103 recettes). Dump conservé hors cluster en filet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)