### PR TITLE
chore: gitignore .claude/ (local Claude Code config)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ kubeconfig
 talosconfig
 # Misc.
 CLAUDE.md
+.claude/
 .scripts/
 /scripts/
 .private/


### PR DESCRIPTION
Ignore le dossier `.claude/` (config locale Claude Code : allowlist de permissions + lock runtime), comme `CLAUDE.md` l'est déjà. Rien de notre travail — tout est déjà sur main via les PRs de la session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)