### PR TITLE
fix(rook-ceph): raise mgr memory limit 1Gi → 2Gi (OOM headroom)

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -80,6 +80,15 @@ spec:
         osd:
           limits:
             memory: 8Gi
+        mgr:
+          # Default 1Gi limit but the mgr peaked at 973Mi (95%) — modules
+          # (prometheus, diskprediction, pg_autoscaler) grow with cluster
+          # activity, so an OOM here is a real risk and degrades cluster mgmt.
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            memory: 2Gi
       storage:
         useAllNodes: true
         useAllDevices: false


### PR DESCRIPTION
Audit ressources : ceph-mgr piquait à **973Mi / 1Gi (95%)**, la marge la plus serrée du cluster (aucun OOMKill sur 14j, mais celui-là était à risque). mgr grossit avec l'activité + modules (prometheus, diskprediction, pg_autoscaler). Bloc resources explicite : request 512Mi, limit 2Gi (~2× le pic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)