### PR TITLE
fix(etcd-snapshot): gzip snapshots + cut retention 14d → 7d (R2 size)

### DIFF
--- a/kubernetes/apps/system-upgrade/etcd-snapshot/app/cronjob.yaml
+++ b/kubernetes/apps/system-upgrade/etcd-snapshot/app/cronjob.yaml
@@ -35,14 +35,19 @@ spec:
                   /talosctl/talosctl --talosconfig=/talos/talosconfig \
                     --nodes="$${TALOS_NODE}" \
                     etcd snapshot "$${SNAP}"
-                  SIZE=$$(stat -c %s "$${SNAP}")
-                  echo "[etcd-snapshot] Snapshot OK ($${SIZE} bytes), uploading to R2…"
-                  aws s3 cp "$${SNAP}" \
-                    "s3://cnpg-backups/etcd-snapshots/etcd-$${TS}.snap" \
+                  RAW=$$(stat -c %s "$${SNAP}")
+                  # The bbolt etcd snapshot is uncompressed (~800MB) and dominates
+                  # the R2 bucket; gzip shrinks it ~2-4x. gunzip before running
+                  # `talosctl etcd snapshot restore` when actually recovering.
+                  gzip "$${SNAP}"
+                  GZ=$$(stat -c %s "$${SNAP}.gz")
+                  echo "[etcd-snapshot] Snapshot $${RAW}B → $${GZ}B gzipped, uploading to R2…"
+                  aws s3 cp "$${SNAP}.gz" \
+                    "s3://cnpg-backups/etcd-snapshots/etcd-$${TS}.snap.gz" \
                     --endpoint-url="$${R2_ENDPOINT}" \
                     --no-progress
-                  echo "[etcd-snapshot] Pruning snapshots older than 14 days…"
-                  CUTOFF=$$(date -u -d '14 days ago' +%Y%m%d)
+                  echo "[etcd-snapshot] Pruning snapshots older than 7 days…"
+                  CUTOFF=$$(date -u -d '7 days ago' +%Y%m%d)
                   aws s3 ls "s3://cnpg-backups/etcd-snapshots/" \
                     --endpoint-url="$${R2_ENDPOINT}" |
                   awk '{print $$4}' |


### PR DESCRIPTION
Le bucket R2 dépassait les 10GB (13GB). Diagnostic : **les snapshots etcd = 11,7GB** (15 × 798MB non compressés), les backups CNPG ne pèsent que ~0,5GB (déjà 7j + bzip2).

- **gzip** le snapshot bbolt avant upload (~2-4×)
- **rétention 14j → 7j**

Nettoyage immédiat déjà fait (8 vieux snapshots supprimés → bucket ~6GB). Projection après gzip+7j : ~2-3GB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)