### PR TITLE
chore: mask etcd-snapshot node IP + global Helm maxHistory 3

### DIFF
--- a/kubernetes/apps/system-upgrade/etcd-snapshot/app/cronjob.yaml
+++ b/kubernetes/apps/system-upgrade/etcd-snapshot/app/cronjob.yaml
@@ -61,7 +61,7 @@ spec:
                   echo "[etcd-snapshot] Done."
               env:
                 - name: TALOS_NODE
-                  value: "192.168.42.41"
+                  value: "${NODE_IP_1}"
                 - name: R2_ENDPOINT
                   value: "https://1aeea9a5d6274c321f9a4805ebaebb51.r2.cloudflarestorage.com"
                 - name: AWS_ACCESS_KEY_ID

--- a/kubernetes/flux/cluster/ks.yaml
+++ b/kubernetes/flux/cluster/ks.yaml
@@ -39,6 +39,10 @@ spec:
                 metadata:
                   name: _
                 spec:
+                  # Keep only 3 Helm release revisions (down from the Flux
+                  # default of 5) — each is a gzipped manifest Secret in etcd;
+                  # 3 is plenty for rollback in a GitOps repo.
+                  maxHistory: 3
                   install:
                     crds: CreateReplace
                     strategy:


### PR DESCRIPTION
Deux petites améliorations d'hygiène :
1. etcd-snapshot : IP node hardcodée → var SOPS `${NODE_IP_1}` (cohérence « caches mes ip »).
2. `maxHistory: 3` global sur toutes les HelmReleases (défaut Flux = 5) → moins de secrets helm.release dans etcd.