### PR TITLE
fix(observability): drop CNPG metric alerts (broken for barman plugin)

### DIFF
--- a/kubernetes/apps/observability/cluster-rules/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/cluster-rules/app/prometheusrule.yaml
@@ -22,36 +22,11 @@ spec:
             summary: "Backup VolSync en retard"
             description: "Le backup VolSync {{ $labels.obj_namespace }}/{{ $labels.obj_name }} est en retard sur son planning depuis plus de 6h."
 
-    # =========================
-    # Backups CNPG (Postgres → R2)
-    # =========================
-    - name: cnpg-backup.rules
-      rules:
-        - alert: CNPGBackupFailed
-          # le dernier essai a échoué et n'a pas réussi depuis
-          expr: |
-            cnpg_collector_last_failed_backup_timestamp
-            > cnpg_collector_last_available_backup_timestamp
-          for: 30m
-          labels:
-            severity: warning
-          annotations:
-            summary: "Backup CNPG en échec"
-            description: "Le dernier backup du cluster CNPG dans {{ $labels.namespace }} ({{ $labels.pod }}) a échoué et n'a pas réussi depuis 30 min."
-
-        - alert: CNPGBackupStale
-          # aucun backup réussi depuis >36h (planning quotidien) ; garde >0
-          # pour ignorer les instances qui ne sauvegardent pas (réplicas)
-          expr: |
-            (time() - cnpg_collector_last_available_backup_timestamp > 129600)
-            and
-            (cnpg_collector_last_available_backup_timestamp > 0)
-          for: 1h
-          labels:
-            severity: warning
-          annotations:
-            summary: "Backup CNPG périmé"
-            description: "Aucun backup CNPG réussi depuis plus de 36h pour {{ $labels.namespace }} ({{ $labels.pod }})."
+    # NB : pas d'alerte sur cnpg_collector_last_available_backup_timestamp — ce
+    # métrique n'est PAS mis à jour par la méthode plugin barman-cloud
+    # (immich/nextcloud restaient à des semaines alors que leurs Backup CRs sont
+    # completed quotidiennement). Le monitoring CNPG fiable passera par le statut
+    # des Backup CRs via KSM CustomResourceState, à ajouter séparément.
 
     # =========================
     # Disque OS des nodes Talos (cache containerd)


### PR DESCRIPTION
Le métrique CNPG `last_available_backup_timestamp` n'est pas màj par la méthode plugin barman-cloud → faux positifs sur immich/nextcloud. On garde VolSync + disque (qui marchent). Monitoring CNPG fiable = via Backup CRs (KSM), en suivi.