### PR TITLE
feat(ai): add CiliumNetworkPolicies for ollama + open-webui

### DIFF
--- a/kubernetes/apps/ai/ollama/app/ciliumnetworkpolicy.yaml
+++ b/kubernetes/apps/ai/ollama/app/ciliumnetworkpolicy.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: ollama
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: ollama
+      app.kubernetes.io/instance: ollama
+  # Only open-webui talks to ollama (OLLAMA_BASE_URL). Ingress-only; egress
+  # stays open so ollama can pull models from the internet.
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: open-webui
+      toPorts:
+        - ports:
+            - port: "11434"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: kube-dns

--- a/kubernetes/apps/ai/ollama/app/kustomization.yaml
+++ b/kubernetes/apps/ai/ollama/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./ocirepository.yaml
   - ./pvc.yaml
   - ./helmrelease.yaml
+  - ./ciliumnetworkpolicy.yaml

--- a/kubernetes/apps/ai/open-webui/app/ciliumnetworkpolicy.yaml
+++ b/kubernetes/apps/ai/open-webui/app/ciliumnetworkpolicy.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: open-webui
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: open-webui
+      app.kubernetes.io/instance: open-webui
+  # Ingress-only (egress stays open: ollama, DNS, internet for auth/models).
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: network
+            gateway.networking.k8s.io/gateway-name: envoy-internal
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: selfhosted
+            app.kubernetes.io/name: dynacat
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: kube-dns

--- a/kubernetes/apps/ai/open-webui/app/kustomization.yaml
+++ b/kubernetes/apps/ai/open-webui/app/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./pvc.yaml
   - ./secret.sops.yaml
   - ./helmrelease.yaml
+  - ./ciliumnetworkpolicy.yaml


### PR DESCRIPTION
Le namespace ai était le seul ns applicatif sans aucune network policy. Ajoute des CNP **ingress-only** (egress ouvert, comme le pattern selfhosted) : open-webui accessible depuis la gateway interne + dynacat ; ollama uniquement depuis open-webui.