### PR TITLE
feat(resources): RAM safety margins on the tight memory limits

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -76,10 +76,15 @@ spec:
         retention: 14d
         retentionSize: 50GB
         resources:
+          # Peak working set ~3.3Gi. Add a memory request (was none → the
+          # scheduler was blind to it) and give the limit ~2x-peak headroom so
+          # a query/compaction spike can't OOM Prometheus (which would take the
+          # whole monitoring + alerting stack with it).
           requests:
             cpu: 100m
+            memory: 2Gi
           limits:
-            memory: 4Gi
+            memory: 6Gi
         storageSpec:
           volumeClaimTemplate:
             spec:

--- a/kubernetes/apps/system-upgrade/etcd-snapshot/app/cronjob.yaml
+++ b/kubernetes/apps/system-upgrade/etcd-snapshot/app/cronjob.yaml
@@ -88,7 +88,7 @@ spec:
                   cpu: 50m
                   memory: 64Mi
                 limits:
-                  memory: 256Mi
+                  memory: 512Mi
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true

--- a/kubernetes/apps/system-upgrade/nut-shutdown/app/deployment.yaml
+++ b/kubernetes/apps/system-upgrade/nut-shutdown/app/deployment.yaml
@@ -142,7 +142,7 @@ spec:
               cpu: 5m
               memory: 16Mi
             limits:
-              memory: 32Mi
+              memory: 64Mi
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true


### PR DESCRIPTION
Nodes à ~44% RAM (pas de pression) → filet de sécurité OOM ciblé sur les limites trop serrées (limite < ~1.6× pic), dimensionnées généreusement (les pics sous-estiment les spikes startup/compaction) :
- prometheus : + request 2Gi (scheduler aveugle à ses 3,3Gi) + limite 4→6Gi
- etcd-snapshot : 256→512Mi
- nut-exporter : 32→64Mi

Non touchés : rook operator/CSI (chart 'unchangable') et postgres CNPG (managé + métrique agrégée trompeuse).