### PR TITLE
feat(dynacat): homepage UX reorg — clearer page tree + cleaner landing

### DIFF
--- a/kubernetes/apps/selfhosted/dynacat/app/configmap.yaml
+++ b/kubernetes/apps/selfhosted/dynacat/app/configmap.yaml
@@ -20,20 +20,8 @@ data:
 
     pages:
       # ── Home ───────────────────────────────────────────────────────────────
-      - name: home
+      - name: Accueil
         columns:
-          # Col 1 : nodes (CPU+RAM via Prometheus) + infra monitor
-          - size: small
-            widgets:
-              - type: custom-api
-                title: Infra
-                cache: 30s
-                update-interval: 30s
-                url: "http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090/api/v1/query?query=label_replace(round(100-avg(rate(node_cpu_seconds_total%7Bmode%3D%22idle%22%2Cinstance%3D%22${NODE_IP_1}%3A9100%22%7D%5B5m%5D))*100%2C0.1)%2C%22t%22%2C%221C%22%2C%22%22%2C%22%22)+or+label_replace(round((1-node_memory_MemAvailable_bytes%7Binstance%3D%22${NODE_IP_1}%3A9100%22%7D/node_memory_MemTotal_bytes%7Binstance%3D%22${NODE_IP_1}%3A9100%22%7D)*100%2C0.1)%2C%22t%22%2C%221R%22%2C%22%22%2C%22%22)+or+label_replace(round((1-node_filesystem_avail_bytes%7Binstance%3D%22${NODE_IP_1}%3A9100%22%2Cmountpoint%3D%22%2Fvar%22%2Cfstype%21~%22tmpfs%7Coverlay%22%7D/node_filesystem_size_bytes%7Binstance%3D%22${NODE_IP_1}%3A9100%22%2Cmountpoint%3D%22%2Fvar%22%2Cfstype%21~%22tmpfs%7Coverlay%22%7D)*100%2C0.1)%2C%22t%22%2C%221O%22%2C%22%22%2C%22%22)+or+label_replace(round(rate(node_disk_io_time_seconds_total%7Binstance%3D%22${NODE_IP_1}%3A9100%22%2Cdevice%3D%22nvme1n1%22%7D%5B5m%5D)*100%2C0.1)%2C%22t%22%2C%221D%22%2C%22%22%2C%22%22)+or+label_replace(round(sum(rate(node_network_receive_bytes_total%7Binstance%3D%22${NODE_IP_1}%3A9100%22%2Cdevice%21~%22lo%7Cveth.%2B%7Ccilium.%2B%7Clxc.%2B%7Ctunl.%2B%22%7D%5B5m%5D))/1048576%2C0.01)%2C%22t%22%2C%221I%22%2C%22%22%2C%22%22)+or+label_replace(round(sum(rate(node_network_transmit_bytes_total%7Binstance%3D%22${NODE_IP_1}%3A9100%22%2Cdevice%21~%22lo%7Cveth.%2B%7Ccilium.%2B%7Clxc.%2B%7Ctunl.%2B%22%7D%5B5m%5D))/1048576%2C0.01)%2C%22t%22%2C%221T%22%2C%22%22%2C%22%22)+or+label_replace(round(100-avg(rate(node_cpu_seconds_total%7Bmode%3D%22idle%22%2Cinstance%3D%22${NODE_IP_2}%3A9100%22%7D%5B5m%5D))*100%2C0.1)%2C%22t%22%2C%222C%22%2C%22%22%2C%22%22)+or+label_replace(round((1-node_memory_MemAvailable_bytes%7Binstance%3D%22${NODE_IP_2}%3A9100%22%7D/node_memory_MemTotal_bytes%7Binstance%3D%22${NODE_IP_2}%3A9100%22%7D)*100%2C0.1)%2C%22t%22%2C%222R%22%2C%22%22%2C%22%22)+or+label_replace(round((1-node_filesystem_avail_bytes%7Binstance%3D%22${NODE_IP_2}%3A9100%22%2Cmountpoint%3D%22%2Fvar%22%2Cfstype%21~%22tmpfs%7Coverlay%22%7D/node_filesystem_size_bytes%7Binstance%3D%22${NODE_IP_2}%3A9100%22%2Cmountpoint%3D%22%2Fvar%22%2Cfstype%21~%22tmpfs%7Coverlay%22%7D)*100%2C0.1)%2C%22t%22%2C%222O%22%2C%22%22%2C%22%22)+or+label_replace(round(rate(node_disk_io_time_seconds_total%7Binstance%3D%22${NODE_IP_2}%3A9100%22%2Cdevice%3D%22nvme1n1%22%7D%5B5m%5D)*100%2C0.1)%2C%22t%22%2C%222D%22%2C%22%22%2C%22%22)+or+label_replace(round(sum(rate(node_network_receive_bytes_total%7Binstance%3D%22${NODE_IP_2}%3A9100%22%2Cdevice%21~%22lo%7Cveth.%2B%7Ccilium.%2B%7Clxc.%2B%7Ctunl.%2B%22%7D%5B5m%5D))/1048576%2C0.01)%2C%22t%22%2C%222I%22%2C%22%22%2C%22%22)+or+label_replace(round(sum(rate(node_network_transmit_bytes_total%7Binstance%3D%22${NODE_IP_2}%3A9100%22%2Cdevice%21~%22lo%7Cveth.%2B%7Ccilium.%2B%7Clxc.%2B%7Ctunl.%2B%22%7D%5B5m%5D))/1048576%2C0.01)%2C%22t%22%2C%222T%22%2C%22%22%2C%22%22)+or+label_replace(round(100-avg(rate(node_cpu_seconds_total%7Bmode%3D%22idle%22%2Cinstance%3D%22${NODE_IP_3}%3A9100%22%7D%5B5m%5D))*100%2C0.1)%2C%22t%22%2C%223C%22%2C%22%22%2C%22%22)+or+label_replace(round((1-node_memory_MemAvailable_bytes%7Binstance%3D%22${NODE_IP_3}%3A9100%22%7D/node_memory_MemTotal_bytes%7Binstance%3D%22${NODE_IP_3}%3A9100%22%7D)*100%2C0.1)%2C%22t%22%2C%223R%22%2C%22%22%2C%22%22)+or+label_replace(round((1-node_filesystem_avail_bytes%7Binstance%3D%22${NODE_IP_3}%3A9100%22%2Cmountpoint%3D%22%2Fvar%22%2Cfstype%21~%22tmpfs%7Coverlay%22%7D/node_filesystem_size_bytes%7Binstance%3D%22${NODE_IP_3}%3A9100%22%2Cmountpoint%3D%22%2Fvar%22%2Cfstype%21~%22tmpfs%7Coverlay%22%7D)*100%2C0.1)%2C%22t%22%2C%223O%22%2C%22%22%2C%22%22)+or+label_replace(round(rate(node_disk_io_time_seconds_total%7Binstance%3D%22${NODE_IP_3}%3A9100%22%2Cdevice%3D%22nvme1n1%22%7D%5B5m%5D)*100%2C0.1)%2C%22t%22%2C%223D%22%2C%22%22%2C%22%22)+or+label_replace(round(sum(rate(node_network_receive_bytes_total%7Binstance%3D%22${NODE_IP_3}%3A9100%22%2Cdevice%21~%22lo%7Cveth.%2B%7Ccilium.%2B%7Clxc.%2B%7Ctunl.%2B%22%7D%5B5m%5D))/1048576%2C0.01)%2C%22t%22%2C%223I%22%2C%22%22%2C%22%22)+or+label_replace(round(sum(rate(node_network_transmit_bytes_total%7Binstance%3D%22${NODE_IP_3}%3A9100%22%2Cdevice%21~%22lo%7Cveth.%2B%7Ccilium.%2B%7Clxc.%2B%7Ctunl.%2B%22%7D%5B5m%5D))/1048576%2C0.01)%2C%22t%22%2C%223T%22%2C%22%22%2C%22%22)+or+label_replace(round(100-avg(rate(node_cpu_seconds_total%7Bmode%3D%22idle%22%2Cinstance%3D%22${NAS_IP}%3A9100%22%7D%5B5m%5D))*100%2C0.1)%2C%22t%22%2C%22NC%22%2C%22%22%2C%22%22)+or+label_replace(round((1-node_memory_MemAvailable_bytes%7Binstance%3D%22${NAS_IP}%3A9100%22%7D/node_memory_MemTotal_bytes%7Binstance%3D%22${NAS_IP}%3A9100%22%7D)*100%2C0.1)%2C%22t%22%2C%22NR%22%2C%22%22%2C%22%22)+or+label_replace(round((1-node_filesystem_avail_bytes%7Binstance%3D%22${NAS_IP}%3A9100%22%2Cmountpoint%3D%22%2F%22%2Cfstype%21~%22tmpfs%7Coverlay%22%7D/node_filesystem_size_bytes%7Binstance%3D%22${NAS_IP}%3A9100%22%2Cmountpoint%3D%22%2F%22%2Cfstype%21~%22tmpfs%7Coverlay%22%7D)*100%2C0.1)%2C%22t%22%2C%22ND%22%2C%22%22%2C%22%22)+or+label_replace(round((1-node_filesystem_avail_bytes%7Binstance%3D%22${NAS_IP}%3A9100%22%2Cmountpoint%3D%22%2Fmnt%2FHDD1X4%22%2Cfstype%21~%22tmpfs%7Coverlay%22%7D/node_filesystem_size_bytes%7Binstance%3D%22${NAS_IP}%3A9100%22%2Cmountpoint%3D%22%2Fmnt%2FHDD1X4%22%2Cfstype%21~%22tmpfs%7Coverlay%22%7D)*100%2C0.1)%2C%22t%22%2C%22NH%22%2C%22%22%2C%22%22)+or+label_replace(round(sum(rate(node_network_receive_bytes_total%7Binstance%3D%22${NAS_IP}%3A9100%22%2Cdevice%21~%22lo%7Cveth.%2B%7Ctunl.%2B%22%7D%5B5m%5D))/1048576%2C0.01)%2C%22t%22%2C%22NI%22%2C%22%22%2C%22%22)+or+label_replace(round(sum(rate(node_network_transmit_bytes_total%7Binstance%3D%22${NAS_IP}%3A9100%22%2Cdevice%21~%22lo%7Cveth.%2B%7Ctunl.%2B%22%7D%5B5m%5D))/1048576%2C0.01)%2C%22t%22%2C%22NT%22%2C%22%22%2C%22%22)"
-                template: |
-                  {{ $1c := (.JSON.Get "data.result.#[metric.t==\"1C\"].value.1").Str }}{{ $1r := (.JSON.Get "data.result.#[metric.t==\"1R\"].value.1").Str }}{{ $1o := (.JSON.Get "data.result.#[metric.t==\"1O\"].value.1").Str }}{{ $1d := (.JSON.Get "data.result.#[metric.t==\"1D\"].value.1").Str }}{{ $1i := (.JSON.Get "data.result.#[metric.t==\"1I\"].value.1").Str }}{{ $1t := (.JSON.Get "data.result.#[metric.t==\"1T\"].value.1").Str }}{{ $2c := (.JSON.Get "data.result.#[metric.t==\"2C\"].value.1").Str }}{{ $2r := (.JSON.Get "data.result.#[metric.t==\"2R\"].value.1").Str }}{{ $2o := (.JSON.Get "data.result.#[metric.t==\"2O\"].value.1").Str }}{{ $2d := (.JSON.Get "data.result.#[metric.t==\"2D\"].value.1").Str }}{{ $2i := (.JSON.Get "data.result.#[metric.t==\"2I\"].value.1").Str }}{{ $2t := (.JSON.Get "data.result.#[metric.t==\"2T\"].value.1").Str }}{{ $3c := (.JSON.Get "data.result.#[metric.t==\"3C\"].value.1").Str }}{{ $3r := (.JSON.Get "data.result.#[metric.t==\"3R\"].value.1").Str }}{{ $3o := (.JSON.Get "data.result.#[metric.t==\"3O\"].value.1").Str }}{{ $3d := (.JSON.Get "data.result.#[metric.t==\"3D\"].value.1").Str }}{{ $3i := (.JSON.Get "data.result.#[metric.t==\"3I\"].value.1").Str }}{{ $3t := (.JSON.Get "data.result.#[metric.t==\"3T\"].value.1").Str }}{{ $nc := (.JSON.Get "data.result.#[metric.t==\"NC\"].value.1").Str }}{{ $nr := (.JSON.Get "data.result.#[metric.t==\"NR\"].value.1").Str }}{{ $nd := (.JSON.Get "data.result.#[metric.t==\"ND\"].value.1").Str }}{{ $nh := (.JSON.Get "data.result.#[metric.t==\"NH\"].value.1").Str }}{{ $ni := (.JSON.Get "data.result.#[metric.t==\"NI\"].value.1").Str }}{{ $nt := (.JSON.Get "data.result.#[metric.t==\"NT\"].value.1").Str }}<div style="display:flex;flex-direction:column;gap:2px;padding:1px 0"><div style="font-size:.7em;font-weight:700;color:#f0d9a0;letter-spacing:.06em;margin-bottom:3px">NODE01</div><div style="display:flex;align-items:center;gap:4px"><span style="font-size:.7em;min-width:36px;opacity:.75">CPU</span><div style="flex:1;background:rgba(255,255,255,.1);border-radius:3px;height:4px"><div style="background:#3b82f6;width:{{ $1c }}%;height:4px;border-radius:3px"></div></div><span style="font-size:.7em;min-width:30px;text-align:right">{{ $1c }}%</span></div><div style="display:flex;align-items:center;gap:4px"><span style="font-size:.7em;min-width:36px;opacity:.75">RAM</span><div style="flex:1;background:rgba(255,255,255,.1);border-radius:3px;height:4px"><div style="background:#f59e0b;width:{{ $1r }}%;height:4px;border-radius:3px"></div></div><span style="font-size:.7em;min-width:30px;text-align:right">{{ $1r }}%</span></div><div style="display:flex;align-items:center;gap:4px"><span style="font-size:.7em;min-width:36px;opacity:.75">OS</span><div style="flex:1;background:rgba(255,255,255,.1);border-radius:3px;height:4px"><div style="background:#10b981;width:{{ $1o }}%;height:4px;border-radius:3px"></div></div><span style="font-size:.7em;min-width:30px;text-align:right">{{ $1o }}%</span></div><div style="display:flex;align-items:center;gap:4px"><span style="font-size:.7em;min-width:36px;opacity:.75">OSD</span><div style="flex:1;background:rgba(255,255,255,.1);border-radius:3px;height:4px"><div style="background:#8b5cf6;width:{{ $1d }}%;height:4px;border-radius:3px"></div></div><span style="font-size:.7em;min-width:30px;text-align:right">{{ $1d }}%</span></div><div style="display:flex;align-items:center;gap:4px"><span style="font-size:.7em;min-width:36px;opacity:.75">NET</span><span style="font-size:.68em;opacity:.7">↓{{ $1i }} ↑{{ $1t }}</span></div><div style="border-top:1px solid rgba(255,255,255,.1);margin:3px 0"></div><div style="font-size:.7em;font-weight:700;color:#f0d9a0;letter-spacing:.06em;margin-bottom:3px">NODE02</div><div style="display:flex;align-items:center;gap:4px"><span style="font-size:.7em;min-width:36px;opacity:.75">CPU</span><div style="flex:1;background:rgba(255,255,255,.1);border-radius:3px;height:4px"><div style="background:#3b82f6;width:{{ $2c }}%;height:4px;border-radius:3px"></div></div><span style="font-size:.7em;min-width:30px;text-align:right">{{ $2c }}%</span></div><div style="display:flex;align-items:center;gap:4px"><span style="font-size:.7em;min-width:36px;opacity:.75">RAM</span><div style="flex:1;background:rgba(255,255,255,.1);border-radius:3px;height:4px"><div style="background:#f59e0b;width:{{ $2r }}%;height:4px;border-radius:3px"></div></div><span style="font-size:.7em;min-width:30px;text-align:right">{{ $2r }}%</span></div><div style="display:flex;align-items:center;gap:4px"><span style="font-size:.7em;min-width:36px;opacity:.75">OS</span><div style="flex:1;background:rgba(255,255,255,.1);border-radius:3px;height:4px"><div style="background:#10b981;width:{{ $2o }}%;height:4px;border-radius:3px"></div></div><span style="font-size:.7em;min-width:30px;text-align:right">{{ $2o }}%</span></div><div style="display:flex;align-items:center;gap:4px"><span style="font-size:.7em;min-width:36px;opacity:.75">OSD</span><div style="flex:1;background:rgba(255,255,255,.1);border-radius:3px;height:4px"><div style="background:#8b5cf6;width:{{ $2d }}%;height:4px;border-radius:3px"></div></div><span style="font-size:.7em;min-width:30px;text-align:right">{{ $2d }}%</span></div><div style="display:flex;align-items:center;gap:4px"><span style="font-size:.7em;min-width:36px;opacity:.75">NET</span><span style="font-size:.68em;opacity:.7">↓{{ $2i }} ↑{{ $2t }}</span></div><div style="border-top:1px solid rgba(255,255,255,.1);margin:3px 0"></div><div style="font-size:.7em;font-weight:700;color:#f0d9a0;letter-spacing:.06em;margin-bottom:3px">NODE03</div><div style="display:flex;align-items:center;gap:4px"><span style="font-size:.7em;min-width:36px;opacity:.75">CPU</span><div style="flex:1;background:rgba(255,255,255,.1);border-radius:3px;height:4px"><div style="background:#3b82f6;width:{{ $3c }}%;height:4px;border-radius:3px"></div></div><span style="font-size:.7em;min-width:30px;text-align:right">{{ $3c }}%</span></div><div style="display:flex;align-items:center;gap:4px"><span style="font-size:.7em;min-width:36px;opacity:.75">RAM</span><div style="flex:1;background:rgba(255,255,255,.1);border-radius:3px;height:4px"><div style="background:#f59e0b;width:{{ $3r }}%;height:4px;border-radius:3px"></div></div><span style="font-size:.7em;min-width:30px;text-align:right">{{ $3r }}%</span></div><div style="display:flex;align-items:center;gap:4px"><span style="font-size:.7em;min-width:36px;opacity:.75">OS</span><div style="flex:1;background:rgba(255,255,255,.1);border-radius:3px;height:4px"><div style="background:#10b981;width:{{ $3o }}%;height:4px;border-radius:3px"></div></div><span style="font-size:.7em;min-width:30px;text-align:right">{{ $3o }}%</span></div><div style="display:flex;align-items:center;gap:4px"><span style="font-size:.7em;min-width:36px;opacity:.75">OSD</span><div style="flex:1;background:rgba(255,255,255,.1);border-radius:3px;height:4px"><div style="background:#8b5cf6;width:{{ $3d }}%;height:4px;border-radius:3px"></div></div><span style="font-size:.7em;min-width:30px;text-align:right">{{ $3d }}%</span></div><div style="display:flex;align-items:center;gap:4px"><span style="font-size:.7em;min-width:36px;opacity:.75">NET</span><span style="font-size:.68em;opacity:.7">↓{{ $3i }} ↑{{ $3t }}</span></div><div style="border-top:1px solid rgba(255,255,255,.1);margin:3px 0"></div><div style="font-size:.7em;font-weight:700;color:#f0d9a0;letter-spacing:.06em;margin-bottom:3px">NAS</div><div style="display:flex;align-items:center;gap:4px"><span style="font-size:.7em;min-width:36px;opacity:.75">CPU</span><div style="flex:1;background:rgba(255,255,255,.1);border-radius:3px;height:4px"><div style="background:#3b82f6;width:{{ $nc }}%;height:4px;border-radius:3px"></div></div><span style="font-size:.7em;min-width:30px;text-align:right">{{ $nc }}%</span></div><div style="display:flex;align-items:center;gap:4px"><span style="font-size:.7em;min-width:36px;opacity:.75">RAM</span><div style="flex:1;background:rgba(255,255,255,.1);border-radius:3px;height:4px"><div style="background:#f59e0b;width:{{ $nr }}%;height:4px;border-radius:3px"></div></div><span style="font-size:.7em;min-width:30px;text-align:right">{{ $nr }}%</span></div><div style="display:flex;align-items:center;gap:4px"><span style="font-size:.7em;min-width:36px;opacity:.75">OS</span><div style="flex:1;background:rgba(255,255,255,.1);border-radius:3px;height:4px"><div style="background:#10b981;width:{{ $nd }}%;height:4px;border-radius:3px"></div></div><span style="font-size:.7em;min-width:30px;text-align:right">{{ $nd }}%</span></div><div style="display:flex;align-items:center;gap:4px"><span style="font-size:.7em;min-width:36px;opacity:.75">HDD1X4</span><div style="flex:1;background:rgba(255,255,255,.1);border-radius:3px;height:4px"><div style="background:#ef4444;width:{{ $nh }}%;height:4px;border-radius:3px"></div></div><span style="font-size:.7em;min-width:30px;text-align:right">{{ $nh }}%</span></div><div style="display:flex;align-items:center;gap:4px"><span style="font-size:.7em;min-width:36px;opacity:.75">NET</span><span style="font-size:.68em;opacity:.7">↓{{ $ni }} ↑{{ $nt }}</span></div></div>
-
-
           # Col 2 : search + services + hacker-news
           - size: full
             widgets:
@@ -41,64 +29,29 @@ data:
                 search-engine: duckduckgo
                 new-tab: true
 
-              - type: group
-                widgets:
-                  - type: monitor
-                    title: Media
-                    sites:
-                      - title: Emby
-                        url: https://emby.${SECRET_DOMAIN}
-                        check-url: http://emby.media.svc.cluster.local:8096
-                        icon: di:emby
-                      - title: Audiobookshelf
-                        url: https://audiobookshelf.${SECRET_DOMAIN}
-                        check-url: http://audiobookshelf.media.svc.cluster.local
-                        icon: di:audiobookshelf
-                  - type: monitor
-                    title: Arr
-                    sites:
-                      - title: Radarr
-                        url: https://radarr.${SECRET_DOMAIN}
-                        check-url: http://radarr.downloads.svc.cluster.local:7878/ping
-                        icon: di:radarr
-                      - title: Sonarr
-                        url: https://sonarr.${SECRET_DOMAIN}
-                        check-url: http://sonarr.downloads.svc.cluster.local:8989/ping
-                        icon: di:sonarr
-                      - title: Bazarr
-                        url: https://bazarr.${SECRET_DOMAIN}
-                        check-url: http://bazarr.downloads.svc.cluster.local:80/ping
-                        icon: di:bazarr
-                      - title: Prowlarr
-                        url: https://prowlarr.${SECRET_DOMAIN}
-                        check-url: http://prowlarr.downloads.svc.cluster.local:80/ping
-                        icon: di:prowlarr
-                      - title: Sabnzbd
-                        url: https://sabnzbd.${SECRET_DOMAIN}
-                        check-url: http://sabnzbd.downloads.svc.cluster.local:80
-                        icon: di:sabnzbd
-                      - title: qBittorrent
-                        url: https://qbittorrent.${SECRET_DOMAIN}
-                        check-url: http://qbittorrent.downloads.svc.cluster.local:8080
-                        icon: di:qbittorrent
-                  - type: monitor
-                    title: Other
-                    sites:
-                      - title: Paperless
-                        url: https://paperless.${SECRET_DOMAIN}
-                        icon: di:paperless-ngx
-                      - title: Tandoor
-                        url: https://tandoor.${SECRET_DOMAIN}
-                        icon: si:tandoorrecipes
-                      - title: Nextcloud
-                        url: https://nextcloud.${SECRET_DOMAIN}
-                        icon: si:nextcloud
-                      - title: IT-Tools
-                        url: https://it-tools.${SECRET_DOMAIN}
-                        icon: di:it-tools
-                      - title: Actual Budget
-                        url: https://budget.${SECRET_DOMAIN}
-                        icon: si:actualbudget
+              - type: monitor
+                title: Favoris
+                sites:
+                  - title: Emby
+                    url: https://emby.${SECRET_DOMAIN}
+                    check-url: http://emby.media.svc.cluster.local:8096
+                    icon: di:emby
+                  - title: Navidrome
+                    url: https://navidrome.${SECRET_DOMAIN}
+                    icon: di:navidrome
+                  - title: Immich
+                    url: https://immich.${SECRET_DOMAIN}
+                    icon: di:immich
+                  - title: Nextcloud
+                    url: https://nextcloud.${SECRET_DOMAIN}
+                    icon: si:nextcloud
+                  - title: Paperless
+                    url: https://paperless.${SECRET_DOMAIN}
+                    icon: di:paperless-ngx
+                  - title: Audiobookshelf
+                    url: https://audiobookshelf.${SECRET_DOMAIN}
+                    check-url: http://audiobookshelf.media.svc.cluster.local
+                    icon: di:audiobookshelf
 
               - type: hacker-news
                 title: Hacker News
@@ -170,7 +123,7 @@ data:
                         icon: si:actualbudget
 
       # ── Media ──────────────────────────────────────────────────────────────
-      - name: media
+      - name: Média
         columns:
           - size: small
             widgets:
@@ -256,7 +209,7 @@ data:
               - type: group
                 widgets:
                   - type: custom-api
-                    title: Bibliothèque
+                    title: Ma bibliothèque
                     allow-insecure-html: true
                     cache: 5m
                     url: "http://emby.media.svc.cluster.local:8096/Items/Counts?api_key=$${EMBY_API_KEY}"
@@ -430,7 +383,7 @@ data:
               - type: group
                 widgets:
                   - type: custom-api
-                    title: Bibliothèque
+                    title: À venir & découvertes
                     allow-insecure-html: true
                     cache: 30m
                     url: "http://sonarr.downloads.svc.cluster.local:8989/api/v3/health?apikey=$${SONARR_API_KEY}"
@@ -529,7 +482,7 @@ data:
                       <div id="dynacat-deezer" class="gls-trigger" onanimationstart="(function(el){fetch('https://api.deezer.com/chart/0/albums?limit=9').then(function(r){return r.json()}).then(function(d){var h='<div style=\'display:grid;grid-template-columns:repeat(3,1fr);gap:5px\'>';(d.data||[]).forEach(function(a){h+='<a href=\''+a.link+'\' target=\'_blank\' style=\'text-decoration:none;color:inherit;display:block;border-radius:5px;overflow:hidden;background:rgba(0,0,0,.06)\' onmouseover=\'this.style.opacity=.75\' onmouseout=\'this.style.opacity=1\'><img src=\''+a.cover_medium+'\' style=\'width:100%;aspect-ratio:1/1;object-fit:cover\'><div style=\'padding:4px\'><div style=\'font-weight:600;font-size:.7em;line-height:1.2;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden\'>'+a.title+'</div><div style=\'font-size:.65em;opacity:.6;margin-top:1px\'>'+(a.artist&&a.artist.name||'')+'</div></div></a>';});h+='</div>';el.innerHTML=h||'<div style=\'font-size:.85em;opacity:.5\'>Aucun album</div>';}).catch(function(){el.innerHTML='<div style=\'font-size:.85em;opacity:.5\'>Indisponible</div>';});})(this)">Chargement...</div>
 
       # ── Stats ──────────────────────────────────────────────────────────────
-      - name: stats
+      - name: Infra
         columns:
           - size: small
             widgets:
@@ -763,7 +716,7 @@ data:
                         icon: di:grafana
 
       # ── Games ──────────────────────────────────────────────────────────────
-      - name: games
+      - name: Jeux
         columns:
           - size: small
             widgets:


### PR DESCRIPTION
Refonte cohérence/arborescence : pages renommées (Accueil/Média/Infra/Jeux), Accueil épurée (Infra dupliqué + monitors redondants retirés → 1 monitor 'Favoris'), Infra reste le hub ops, et les 2 groupes 'Bibliothèque' renommés (Ma bibliothèque / À venir & découvertes).