### PR TITLE
fix(dynacat): RSS feeds — swap Bellingcat for r/OSINT + Guardian

### DIFF
--- a/kubernetes/apps/selfhosted/dynacat/app/configmap.yaml
+++ b/kubernetes/apps/selfhosted/dynacat/app/configmap.yaml
@@ -65,12 +65,14 @@ data:
                 limit: 12
                 collapse-after: 5
                 feeds:
-                  - url: https://www.bellingcat.com/feed/
-                    title: Bellingcat
+                  - url: https://www.reddit.com/r/OSINT.rss
+                    title: r/OSINT
                   - url: https://feeds.bbci.co.uk/news/world/rss.xml
                     title: BBC World
                   - url: https://www.aljazeera.com/xml/rss/all.xml
                     title: Al Jazeera
+                  - url: https://www.theguardian.com/world/rss
+                    title: The Guardian
               - type: rss
                 title: Tech & Homelab
                 limit: 10


### PR DESCRIPTION
Bellingcat (Cloudflare) ne se parse pas dans glance → remplacé par r/OSINT + The Guardian (fiable) pour que Monde & OSINT reste peuplé.