### PR TITLE
fix: resolve issues surfaced by the new Infra dashboard widgets

### DIFF
--- a/kubernetes/apps/network/certificates/export/certificate.yaml
+++ b/kubernetes/apps/network/certificates/export/certificate.yaml
@@ -8,7 +8,11 @@ spec:
   dnsNames:
     - ${SECRET_DOMAIN}
     - "*.${SECRET_DOMAIN}"
-  duration: 160h
+  # Let's Encrypt issues 90-day certs. duration must match (2160h) so
+  # cert-manager schedules renewal correctly; with the old 160h it renewed
+  # only ~53h before the real expiry (2-day buffer). renewBefore 30 days.
+  duration: 2160h
+  renewBefore: 720h
   issuerRef:
     name: letsencrypt-production
     kind: ClusterIssuer

--- a/kubernetes/apps/observability/cluster-rules/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/cluster-rules/app/prometheusrule.yaml
@@ -71,3 +71,16 @@ spec:
           annotations:
             summary: "Disque OS Talos > 80%"
             description: "Le disque OS (/var, cache containerd) de {{ $labels.instance }} est à {{ $value | printf \"%.0f\" }}% — le GC d'images (seuil 70%) ne suit peut-être pas."
+
+        - alert: NodeMemoryHigh
+          # Remplace la native NodeMemoryHighUtilization (désactivée) : exclut le
+          # NAS dont l'ARC ZFS (~94%) est réclamable et déclenchait un faux positif.
+          expr: |
+            100 * (1 - node_memory_MemAvailable_bytes{job="node-exporter",instance!="${NAS_IP}:9100"}
+            / node_memory_MemTotal_bytes{job="node-exporter",instance!="${NAS_IP}:9100"}) > 90
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Mémoire node élevée"
+            description: "{{ $labels.instance }} utilise {{ $value | printf \"%.0f\" }}% de RAM."

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -15,6 +15,11 @@ spec:
       valuesKey: flux-metrics.yaml
   values:
     cleanPrometheusOperatorObjectNames: true
+    defaultRules:
+      disabled:
+        # Fires on the TrueNAS node (ZFS ARC sits ~94%, reclaimable → false
+        # positive). Replaced by a NAS-excluded NodeMemoryHigh in cluster-rules.
+        NodeMemoryHighUtilization: true
     alertmanager:
       route:
         main:


### PR DESCRIPTION
Les nouveaux widgets ont remonté de vrais soucis :
- **Cert wildcard** : duration 160h→2160h + renewBefore 720h (renouvelait à 2j de l'expiry → 30j maintenant, + ré-émission immédiate)
- **NodeMemoryHighUtilization** : désactivée (faux positif sur le NAS/ARC ZFS) → remplacée par une version NAS-excluded
- Jobs échoués stales + vieux ReplicaSets dynacat nettoyés (impératif)
- CephPoolGrowthWarning = transitoire (mon restart mgr), s'auto-résout en ~2j