### PR TITLE
fix(fluent-bit): cap memory + fix kube-API buffer (was ~2Gi/node)

### DIFF
--- a/kubernetes/apps/observability/fluent-bit/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/fluent-bit/app/helmrelease.yaml
@@ -48,6 +48,10 @@ spec:
           k8s-logging.exclude on
           namespace_labels off
           annotations off
+          # Default kube-API client buffer is 32K — large pod objects overflow it
+          # ("cannot increase buffer: max=32000"), failing enrichment and leaking
+          # memory over time. 1M comfortably fits any pod's metadata.
+          buffer_size 1M
 
         [FILTER]
           name nest
@@ -107,3 +111,12 @@ spec:
     serviceMonitor:
       enabled: true
     logLevel: warn
+    # fluent-bit had no limits and crept to ~2Gi/node for only ~6 logs/s. Cap it:
+    # if it ever balloons again it's OOM-restarted, and the filesystem buffer
+    # (storage.type filesystem) means no log loss across the restart.
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        memory: 256Mi


### PR DESCRIPTION
fluent-bit montait à ~2Gi/nœud pour 6 logs/s. Causes : buffer kube-API 32K (overflow sur gros pods → fuite) + aucune limite. Fix : buffer_size 1M + limite 256Mi (OOM-restart sans perte grâce au buffer disque).