### PR TITLE
fix(ci): bump trivy to existing release v0.71.1 (image-scan was 404ing)

### DIFF
--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -81,7 +81,8 @@ jobs:
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ matrix.image }}
-          version: "v0.69.1"
+          # renovate: datasource=github-releases depName=aquasecurity/trivy
+          version: v0.71.1
           severity: "CRITICAL,HIGH"
           ignore-unfixed: true
           format: "table"


### PR DESCRIPTION
## Problème
Le workflow `image-scan.yaml` pinnait `version: "v0.69.1"` pour le binaire trivy — **cette release n'existe pas** (404, version yankée/sautée). L'`install.sh` de trivy-action trouvait le tag mais le téléchargement du tarball 404ait → exit code 1 en ~2s, **avant** tout scan.

Conséquence : le gate *Image Scan Success* échouait sur **toute** PR modifiant un manifeste contenant une image (constaté sur #336).

## Fix
- `version: v0.71.1` (dernière release réelle)
- Annotation `# renovate: datasource=github-releases depName=aquasecurity/trivy` → la version est désormais suivie par le `customManager` "annotated dependencies" existant, donc plus de dérive/404 silencieux.

Bug préexistant, indépendant du SHA-pin de trivy-action (#335) qui ne faisait que figer le même code que `@v0.36.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)