### PR TITLE
fix(ci): checkout repo in image-scan job (trivy .trivyignore not found)

### DIFF
--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -77,6 +77,14 @@ jobs:
       matrix:
         image: ${{ fromJSON(needs.list-images.outputs.images) }}
     steps:
+      # The scan job needs the repo checked out so trivy can read .trivyignore
+      # (trivyignores below). Without this the workspace is empty and trivy
+      # errors "cannot find ignorefile '.trivyignore'".
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Trivy scan
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:


### PR DESCRIPTION
## Problème
3e bug empilé du workflow `image-scan` (révélé après le fix de version #337). Le job `scan` n'avait **aucun `actions/checkout`** avant l'étape trivy → workspace vide → :
```
ERROR: cannot find ignorefile '.trivyignore'.
```
Le `.trivyignore` est pourtant bien commité ; il n'était simplement jamais présent dans le workspace du job.

## Fix
Ajout d'une étape `actions/checkout` (pin standard du repo, `persist-credentials: false`) avant le scan.

## Note
Avec ce fix, le workflow tourne enfin de bout en bout. Le scan de l'image ceph va donc réellement s'exécuter — s'il remonte des CVE CRITICAL/HIGH *corrigeables*, le `.trivyignore` est l'échappatoire prévue (« To be populated after first full CI run »).

🤖 Generated with [Claude Code](https://claude.com/claude-code)