### PR TITLE
feat(ci): image-scan report-only + SARIF upload to Security tab

### DIFF
--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -72,6 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      security-events: write # upload SARIF to the Security tab
     strategy:
       fail-fast: false
       matrix:
@@ -93,13 +94,25 @@ jobs:
           version: v0.71.1
           severity: "CRITICAL,HIGH"
           ignore-unfixed: true
-          format: "table"
-          exit-code: "1"
+          format: "sarif"
+          output: "trivy-results.sarif"
+          # Report-only. These are upstream images we consume, not build, so a
+          # finding isn't ours to fix — gating here would just block Renovate
+          # auto-merges on CVEs we can't patch. exit-code 0 = never fail on
+          # vulns; results go to the Security tab (uploaded below) for triage.
+          exit-code: "0"
           vuln-type: "os,library"
           timeout: "5m"
           trivyignores: ".trivyignore"
         env:
           TRIVY_DISABLE_VEX_NOTICE: "true"
+
+      - name: Upload SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        with:
+          sarif_file: "trivy-results.sarif"
+          # One category per image so matrix uploads don't overwrite each other.
+          category: "trivy:${{ matrix.image }}"
 
   scan-status:
     name: Image Scan Success
@@ -111,6 +124,6 @@ jobs:
         if: ${{ contains(needs.*.result, 'failure') }}
         run: exit 1
 
-      - name: All clean or skipped?
+      - name: Scans completed?
         if: ${{ !(contains(needs.*.result, 'failure')) }}
-        run: echo "No fixable CRITICAL/HIGH vulns in changed images"
+        run: echo "Image scans completed (report-only — see the Security tab for findings)"


### PR DESCRIPTION
## Pourquoi
Le scan trivy cible des images **upstream qu'on consomme, pas qu'on build**. Une CVE corrigeable dedans n'est pas la nôtre à corriger → un gate bloquant ne ferait que stopper les auto-merges Renovate sur des vulns qu'on ne peut pas patcher. Best practice pour des images tierces : **report-only**.

## Changements
- `exit-code: 1 → 0` — ne bloque plus jamais le merge sur des vulns (une vraie erreur de scan/infra reste visible via le gate `scan-status`)
- `format: table → sarif` + `output: trivy-results.sarif`, uploadé vers l'onglet **Security** via `github/codeql-action/upload-sarif` (épinglé `# v3`), une `category` par image pour éviter l'écrasement en matrice
- `security-events: write` ajouté pour l'upload

## Résultat
Les findings sont **browsables, dédupliqués et dismissables** dans l'onglet Security au lieu de bloquer les PRs. On réintroduira un gate bloquant uniquement sur des images qu'on construirait nous-mêmes, le cas échéant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)