### PR TITLE
test(ci): validate image-scan SARIF upload [DO NOT MERGE]

### DIFF
--- a/kubernetes/apps/network/echo/app/helmrelease.yaml
+++ b/kubernetes/apps/network/echo/app/helmrelease.yaml
@@ -15,6 +15,7 @@ spec:
         strategy: RollingUpdate
         containers:
           app:
+            # ci: no-op comment to trigger image-scan SARIF validation (PR will be closed)
             image:
               repository: ghcr.io/mendhak/http-https-echo
               tag: 41


### PR DESCRIPTION
Temporary PR to force the trivy image-scan to run end-to-end and confirm the SARIF upload to the Security tab works. Touches `network/echo` (single small image, value unchanged). **Will be closed without merging.**