### PR TITLE
feat(open-webui): VolSync backup for open-webui-data

### DIFF
--- a/kubernetes/apps/ai/open-webui/app/kustomization.yaml
+++ b/kubernetes/apps/ai/open-webui/app/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
   - ./pvc.yaml
   - ./secret.sops.yaml
   - ./helmrelease.yaml
+  - ./volsync.yaml
   - ./ciliumnetworkpolicy.yaml

--- a/kubernetes/apps/ai/open-webui/app/volsync.yaml
+++ b/kubernetes/apps/ai/open-webui/app/volsync.yaml
@@ -1,0 +1,56 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas-ebx.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: open-webui-volsync
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: open-webui-volsync-secret
+    template:
+      data:
+        KOPIA_PASSWORD: "{{ .KOPIA_PASSWORD }}"
+        KOPIA_REPOSITORY: filesystem:///mnt/repository
+  dataFrom:
+    - extract:
+        key: volsync-template
+---
+# yaml-language-server: $schema=https://kubernetes-schemas-ebx.pages.dev/volsync.backube/replicationsource_v1alpha1.json
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: open-webui-data
+spec:
+  # Back up the existing in-place PVC (webui.db, uploads, vector_db) — no PVC
+  # replacement, so the 890Mi of existing data is adopted with zero downtime.
+  sourcePVC: open-webui-data
+  trigger:
+    schedule: "0 4 * * *"
+  kopia:
+    accessModes:
+      - ReadWriteOnce
+    compression: zstd-fastest
+    copyMethod: Snapshot
+    moverSecurityContext:
+      # open-webui's data is owned by uid 1000; fsGroup makes the snapshot
+      # readable, and writing to the NFS repo as a non-root uid avoids the
+      # TrueNAS root_squash hang.
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+    moverVolumes:
+      - mountPath: repository
+        volumeSource:
+          nfs:
+            path: /mnt/HDD1X4/VolsyncKopia
+            server: ${NAS_IP}
+    parallelism: 2
+    repository: open-webui-volsync-secret
+    retain:
+      hourly: 24
+      daily: 7
+    storageClassName: ceph-block
+    volumeSnapshotClassName: csi-ceph-blockpool


### PR DESCRIPTION
## Pourquoi
`ai/open-webui-data` était la seule PVC stateful **sans aucune couverture backup** (ni VolSync, ni CNPG). Elle contient ~890 Mo de vraie donnée utilisateur non régénérable : `webui.db` (comptes, **historiques de conversations**, prompts), `uploads/`, `vector_db/` (embeddings RAG).

## Quoi
`app/volsync.yaml` (ExternalSecret + ReplicationSource) sur le **même pattern que tandoor** — backup de la PVC existante en place :
- **Aucun remplacement de PVC / pas de `dataSourceRef`** → les 890 Mo sont adoptés sans downtime ni risque (le composant standard recrée la PVC, ce qui aurait buté sur l'immutabilité de `dataSourceRef`).
- Snapshot Kopia quotidien (4h) → repo NFS, rétention `hourly:24 daily:7`.
- `moverSecurityContext` uid 1000 (propriétaire des données ; écriture non-root → évite le hang root_squash TrueNAS).
- CNP open-webui = ingress-only sur les pods de l'app → le mover joint le NFS sans changement réseau.

## Suite
Après merge + réconciliation, je déclencherai un backup manuel pour valider le 1er snapshot dans le repo Kopia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)