### PR TITLE
fix(arrem-sync): retry on transient failures (backoffLimit 2)

### DIFF
--- a/kubernetes/apps/media/arrem-sync/app/helmrelease.yaml
+++ b/kubernetes/apps/media/arrem-sync/app/helmrelease.yaml
@@ -15,7 +15,11 @@ spec:
         type: cronjob
         cronjob:
           schedule: "45 */6 * * *"
-          backoffLimit: 0
+          # Retry on transient failures: the job treats a single unreachable Arr
+          # (e.g. a brief CoreDNS EAI_AGAIN blip) as fatal. With restartPolicy
+          # Never, backoffLimit > 0 reschedules a fresh pod, so a momentary DNS
+          # hiccup no longer fails the whole 6h sync.
+          backoffLimit: 2
           concurrencyPolicy: Forbid
           failedJobsHistory: 1
           successfulJobsHistory: 1


### PR DESCRIPTION
## Symptôme
Le CronJob `arrem-sync` (sync tags Arr→Emby, toutes les 6h) a échoué sur la run de 12:45 :
```
Connection to sonarr successful
radarr... NameResolutionError: Failed to resolve 'radarr.downloads.svc.cluster.local' ([Errno -3] Try again)
❌ Failed to connect to services: radarr_2
```

## Cause racine
- radarr était **disponible** à 12:45 (1 replica, jamais scaled-to-zero) → blip **DNS/réseau transitoire** (`EAI_AGAIN`), pas une panne radarr.
- Le CronJob avait `backoffLimit: 0` + `restartPolicy: Never` → **aucun retry** : un seul blip transitoire sur une instance = job entier en échec.

## Fix
`backoffLimit: 0 → 2`. Avec `restartPolicy: Never`, le job replanifie un pod neuf sur échec → absorbe les hoquets DNS/réseau momentanés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)