### PR TITLE
fix(tuppr): deploy orphaned PrometheusRule + add NodeStuckCordoned alert

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/kustomization.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./kubernetesupgrade.yaml
   - ./talosupgrade.yaml
+  - ./prometheusrule.yaml

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/prometheusrule.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/prometheusrule.yaml
@@ -91,3 +91,26 @@ spec:
               A {{ $labels.upgrade_type }} upgrade job has been active for more
               than 1 hour, which exceeds the expected duration. The job may be
               stuck. Check the job logs in the controller namespace.
+
+    - name: tuppr.nodes
+      rules:
+        # Safety net for the failure mode where a Talos upgrade aborts (e.g. a
+        # drain blocked by a single-instance PodDisruptionBudget) and Tuppr
+        # leaves the node cordoned. A stranded cordon keeps node-pinned Ceph
+        # mon/osd pods Pending, silently degrading storage until the cascade is
+        # noticed elsewhere. 20m clears a normal drain+reboot+rejoin window.
+        - alert: NodeStuckCordoned
+          expr: kube_node_spec_unschedulable == 1
+          for: 20m
+          labels:
+            severity: warning
+          annotations:
+            summary: >-
+              Node {{ $labels.node }} has been cordoned for over 20 minutes
+            description: >-
+              Node {{ $labels.node }} is unschedulable (cordoned) and has been
+              for more than 20 minutes. A failed or aborted Talos/Tuppr upgrade
+              can leave a node cordoned, stranding node-pinned Ceph mon/osd pods
+              (Pending) and degrading the cluster. Verify the node is healthy
+              ({{ $labels.node }} Ready, target Talos version, MachineStatus
+              STAGE=running) and run `kubectl uncordon {{ $labels.node }}`.


### PR DESCRIPTION
## Why

Two related observability gaps surfaced during a Talos upgrade incident on 2026-06-25:

1. **The tuppr `PrometheusRule` was never deployed.** `prometheusrule.yaml` existed in `tuppr/upgrades/` but was not referenced by that directory's `kustomization.yaml`, so `kubectl get prometheusrule -n system-upgrade` returned nothing. Every tuppr alert (`TalosUpgradeFailed`, `TalosUpgradeNodeFailed`, etc.) was dead config — which is why a failed v1.13.5 upgrade on node03 produced **no upgrade alert**.

2. **Nothing alerted on a stranded cordon.** When a Talos upgrade aborts (here: the drain deadlocked on a single-instance CNPG PDB, `games/romm-postgres-1`), tuppr leaves the node `SchedulingDisabled` and does not uncordon it. That stranded cordon keeps node-pinned Ceph `mon`/`osd` pods `Pending`, degrading storage. The only signal today was the downstream Ceph cascade (QuorumAtRisk, PGs unclean), ~45m later.

## What

- Wire `./prometheusrule.yaml` into `tuppr/upgrades/kustomization.yaml` so the existing upgrade alerts actually deploy.
- Add a `NodeStuckCordoned` alert (`kube_node_spec_unschedulable == 1` for 20m, severity `warning`) so a stranded cordon is caught directly. 20m clears a normal drain+reboot+rejoin window to avoid firing during legitimate upgrades.

## Validation

- `kubectl kustomize kubernetes/apps/system-upgrade/tuppr/upgrades` builds and now emits the `PrometheusRule` with groups `tuppr.talosupgrade`, `tuppr.kubernetesupgrade`, `tuppr.jobs`, `tuppr.nodes`.
- Confirmed `kube_node_spec_unschedulable` exists in-cluster (kube-state-metrics; one series per node, value 1 when cordoned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)