### PR TITLE
fix(tuppr): skip node drain on Talos upgrade (nodrain: true)

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -9,6 +9,13 @@ spec:
     # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
     version: v1.13.5
   policy:
+    # Single-instance CNPG DBs (e.g. games/romm-postgres) have a PDB that
+    # makes them unevictable, so the pre-upgrade drain deadlocks and the
+    # upgrade aborts before rebooting, stranding the node cordoned. Skip the
+    # drain: the reboot is graceful at the Talos level (etcd leaves/rejoins,
+    # Ceph mon/osd cycle, pods reschedule) and the Ceph HEALTH_OK health gate
+    # below still sequences nodes safely.
+    nodrain: true
     rebootMode: powercycle
   healthChecks:
     - apiVersion: volsync.backube/v1alpha1


### PR DESCRIPTION
## Why

Talos upgrades have been failing on whichever node hosts an **unevictable** pod. The pre-upgrade **drain deadlocks** on single-instance CNPG databases — `games/romm-postgres` has a PDB with `minAvailable: 1` and 0 allowed disruptions, so its only pod can never be evicted. The drain exceeds its timeout, `talosctl` aborts **before rebooting**, and the node is left on the old version and **cordoned**, stranding node-pinned Ceph `mon`/`osd` pods as `Pending` (→ degraded storage cascade).

Observed directly on 2026-06-25 during the node03 v1.13.5 upgrade:
```
error draining node "node03": error when evicting pods/"romm-postgres-1" -n "games":
... would exceed context deadline
```
tuppr drains by default (`nodrain: false`), so it hits this whenever such a pod is pinned to the target node. node02 upgrades fine only because it isn't hosting one.

## What

Set `policy.nodrain: true`. The upgrade skips the Kubernetes drain; the reboot is still graceful at the Talos level (etcd leaves/rejoins, Ceph mon/osd cycle, pods reschedule), and the existing **`CephCluster` HEALTH_OK health gate** still sequences nodes safely between reboots.

## Trade-off

Without the drain, pods on the rebooting node are terminated by the reboot rather than gracefully evicted first. For this cluster that's acceptable: the node-pinned Ceph daemons and single-instance DBs would be disrupted by the reboot regardless, and the health gate prevents moving to the next node until Ceph is healthy again.

## Validation

- `talosctl upgrade --drain=false` (the equivalent) was used manually to successfully bring node03 to v1.13.5.
- `kubectl apply --dry-run=server` accepts `nodrain: true` against the live TalosUpgrade CRD.

Follow-up to #375 (upgrade-failure alerting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)