### PR TITLE
fix(romm): disable CNPG PDB to unblock node drains (enablePDB: false)

### DIFF
--- a/kubernetes/apps/games/romm/app/cluster.yaml
+++ b/kubernetes/apps/games/romm/app/cluster.yaml
@@ -6,6 +6,12 @@ metadata:
   name: romm-postgres
 spec:
   instances: 1
+  # Single-instance cluster: CNPG's auto-created PDB (minAvailable=1) makes the
+  # sole pod unevictable, which deadlocks node drains during Talos upgrades and
+  # strands the node cordoned (the 2026-06-25 incident). Disable it so a drain
+  # can evict-and-reschedule this pod; a brief restart on drain is acceptable
+  # for a single-instance DB. Belt-and-suspenders with tuppr policy nodrain=true.
+  enablePDB: false
   imageName: ghcr.io/cloudnative-pg/postgresql:16
   storage:
     storageClass: ceph-block


### PR DESCRIPTION
## Why

`romm-postgres` is a **single-instance** CNPG cluster. CNPG auto-creates a PDB for it (`romm-postgres-primary`, `minAvailable: 1`, 0 allowed disruptions), which makes its only pod **unevictable**. When the node hosting it is drained for a Talos upgrade, eviction never succeeds, the drain times out, and the upgrade aborts before rebooting — stranding the node cordoned. That was the trigger of the 2026-06-25 incident (stranded cordon → Ceph mon/osd Pending → degraded storage cascade):

```
error draining node "node03": error when evicting pods/"romm-postgres-1" -n "games":
... would exceed context deadline
```

## What

Set `spec.enablePDB: false` on the romm-postgres Cluster so CNPG does not create the blocking PDB. A drain can then evict-and-reschedule the pod (brief restart, acceptable for a single-instance DB) instead of deadlocking.

This is **defense-in-depth** alongside the cluster-wide tuppr `nodrain: true` (#376): it also protects against a manual `kubectl drain` or a future revert of the tuppr setting.

## Validation

- `kubectl kustomize kubernetes/apps/games/romm/app` builds.
- `kubectl apply --dry-run=server` accepts `enablePDB: false` against the live CNPG `Cluster` CRD.

## Follow-up note

Other single-instance CNPG DBs (e.g. `tandoor`, `sparkyfitness`) likely have the same unevictable PDB. They're covered for upgrades by `nodrain: true`, but could get the same `enablePDB: false` treatment for drain-safety if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)