### PR TITLE
fix(immich): postgres 512Mi→2Gi to unstick v3.0.0 upgrade + pgdump retries

### DIFF
--- a/kubernetes/apps/selfhosted/immich/app/cluster.yaml
+++ b/kubernetes/apps/selfhosted/immich/app/cluster.yaml
@@ -18,9 +18,14 @@ spec:
   resources:
     requests:
       cpu: 100m
-      memory: 256Mi
-    limits:
       memory: 512Mi
+    # 2Gi (was 512Mi): the immich v2.6.3 -> v3.0.0 upgrade (chart 0.13.1) ran the
+    # v3 schema migration + geodata re-import, whose working set blew past the
+    # 512Mi limit and OOM-killed the primary in a loop. That stalled the Helm
+    # upgrade (Deployment never went Ready) and wedged it into a failed rollback.
+    # 2Gi gives headroom for the upgrade spike per the ">= 2x peak" rule.
+    limits:
+      memory: 2Gi
   bootstrap:
     initdb:
       database: immich

--- a/kubernetes/apps/selfhosted/immich/app/pgdump.yaml
+++ b/kubernetes/apps/selfhosted/immich/app/pgdump.yaml
@@ -10,7 +10,11 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
-      backoffLimit: 1
+      # 3 (was 1): the weekly Sunday-04:30 run failed 2026-06-28 and 2026-07-05
+      # on transient blips (NAS NFS / postgres-rw during the maintenance window);
+      # the dump itself works. More retries ride out the transient, same as
+      # arrem-sync (36eeb6ec).
+      backoffLimit: 3
       template:
         spec:
           restartPolicy: OnFailure

--- a/kubernetes/apps/selfhosted/nextcloud/app/pgdump.yaml
+++ b/kubernetes/apps/selfhosted/nextcloud/app/pgdump.yaml
@@ -10,7 +10,11 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
-      backoffLimit: 1
+      # 3 (was 1): the weekly Sunday-04:00 run failed 2026-06-28 and 2026-07-05
+      # on transient blips (NAS NFS / postgres-rw during the maintenance window);
+      # the dump itself works. More retries ride out the transient, same as
+      # arrem-sync (36eeb6ec).
+      backoffLimit: 3
       template:
         spec:
           restartPolicy: OnFailure


### PR DESCRIPTION
## Incident summary

The Renovate immich chart bump **0.12.0 → 0.13.1** (app **v2.6.3 → v3.0.0**) got wedged:

1. Flux upgraded to v3.0.0, which ran the v3 schema migration + geodata re-import.
2. That working set exceeded the **512Mi** postgres limit → **OOM-killed the primary in a loop** (immich-postgres-1 had 29+ restarts, unclean shutdowns).
3. The Helm upgrade timed out (Deployment never went Ready) → remediation **rolled back to v2.6.3**, which then **cannot start** against the already-migrated v3 DB (`corrupted migrations: ...AddChecksumAlgorithm is missing`).
4. Two immich-server replicasets (v3.0.0 + v2.6.3) flapped, hammering postgres and sustaining the OOM loop.

The DB is already on the v3 schema, so **rolling forward is the lossless path** — it just needs postgres headroom to let the already-declared v3.0.0 upgrade finish.

## Changes

- **`immich/app/cluster.yaml`**: postgres `requests.memory` 256Mi→512Mi, `limits.memory` **512Mi→2Gi**. This is the fix that unsticks the upgrade.
- **`immich/app/pgdump.yaml` + `nextcloud/app/pgdump.yaml`**: weekly pg_dump-to-NAS `backoffLimit` **1→3**. Both dumps failed on the 2026-06-28 and 2026-07-05 Sunday runs on transient blips (mechanism verified working); mirrors the `arrem-sync` fix (36eeb6ec).

## Live actions already taken (incident containment)
- Suspended the immich HelmRelease + scaled `immich-server` to 0 → postgres recovered.
- Re-cloned the stranded `immich-postgres-2` replica (timeline divergence from the OOM failovers: `requested timeline 47 does not contain minimum recovery point on timeline 44`) — fresh clone from the healthy primary.
- Cleared 5 stale failed Job objects (pgdump ×4, arrem-sync ×1).

## After merge
1. Flux applies `cluster.yaml` → postgres rolls to 2Gi (immich at 0 replicas, no load, safe).
2. Resume + force-reconcile the HelmRelease → v3.0.0 upgrade completes against 2Gi postgres.
3. Verify immich-server healthy on v3.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)