### PR TITLE
feat(system-upgrade): add job-cleaner CronJob to prune finished jobs

### DIFF
--- a/kubernetes/apps/system-upgrade/job-cleaner/app/cronjob.yaml
+++ b/kubernetes/apps/system-upgrade/job-cleaner/app/cronjob.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: job-cleaner
+spec:
+  # Daily janitor: completed Jobs (and their finished pods) accumulate because
+  # CronJob history limits are count-based and standalone/manual Jobs have no
+  # TTL. This enforces an age-based cleanup cluster-wide. FAILED jobs are left
+  # untouched so KubeJobFailed keeps alerting until they are investigated.
+  schedule: "30 3 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          serviceAccountName: job-cleaner
+          automountServiceAccountToken: true
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: job-cleaner
+              # renovate: datasource=docker depName=docker.io/alpine/k8s
+              image: docker.io/alpine/k8s:1.35.3
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -eu
+                  TTL="$${TTL_SECONDS}"
+                  echo "[job-cleaner] deleting Succeeded jobs/pods finished > $${TTL}s ago"
+
+                  # 1) Succeeded Jobs older than TTL — cascade-deletes their pods.
+                  #    Failed jobs (no completionTime) are intentionally kept.
+                  kubectl get jobs -A -o json | jq -r --argjson ttl "$${TTL}" '
+                    .items[]
+                    | select(.status.completionTime != null)
+                    | select((now - (.status.completionTime | fromdateiso8601)) > $ttl)
+                    | "\(.metadata.namespace) \(.metadata.name)"
+                  ' | while read -r ns name; do
+                        echo "  del job $${ns}/$${name}"
+                        kubectl delete job -n "$${ns}" "$${name}" --ignore-not-found --wait=false
+                      done
+
+                  # 2) Orphan Succeeded pods older than TTL (owning job already gone).
+                  kubectl get pods -A --field-selector=status.phase==Succeeded -o json \
+                    | jq -r --argjson ttl "$${TTL}" '
+                      .items[]
+                      | ([ (.status.containerStatuses // [])[].state.terminated.finishedAt ]
+                          | map(select(. != null)) | max) as $fin
+                      | ($fin // .status.startTime // .metadata.creationTimestamp) as $t
+                      | select((now - ($t | fromdateiso8601)) > $ttl)
+                      | "\(.metadata.namespace) \(.metadata.name)"
+                    ' | while read -r ns name; do
+                          echo "  del pod $${ns}/$${name}"
+                          kubectl delete pod -n "$${ns}" "$${name}" --ignore-not-found --wait=false
+                        done
+
+                  echo "[job-cleaner] done"
+              env:
+                - name: HOME
+                  value: /tmp
+                - name: TTL_SECONDS
+                  value: "86400" # 24h
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 64Mi
+                limits:
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+          volumes:
+            - name: tmp
+              emptyDir: {}

--- a/kubernetes/apps/system-upgrade/job-cleaner/app/kustomization.yaml
+++ b/kubernetes/apps/system-upgrade/job-cleaner/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./rbac.yaml
+  - ./cronjob.yaml

--- a/kubernetes/apps/system-upgrade/job-cleaner/app/rbac.yaml
+++ b/kubernetes/apps/system-upgrade/job-cleaner/app/rbac.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: job-cleaner
+  namespace: system-upgrade
+---
+# Least-privilege: only list/delete finished Jobs and their Pods, cluster-wide.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: job-cleaner
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: job-cleaner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: job-cleaner
+subjects:
+  - kind: ServiceAccount
+    name: job-cleaner
+    namespace: system-upgrade

--- a/kubernetes/apps/system-upgrade/job-cleaner/ks.yaml
+++ b/kubernetes/apps/system-upgrade/job-cleaner/ks.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas-ebx.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: job-cleaner
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/system-upgrade/job-cleaner/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: system-upgrade
+  wait: false

--- a/kubernetes/apps/system-upgrade/kustomization.yaml
+++ b/kubernetes/apps/system-upgrade/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - ./tuppr/ks.yaml
   - ./nut-shutdown/ks.yaml
   - ./etcd-snapshot/ks.yaml
+  - ./job-cleaner/ks.yaml


### PR DESCRIPTION
## What

A daily janitor CronJob (`system-upgrade/job-cleaner`) that prunes finished Jobs and their pods cluster-wide, so completed job pods stop piling up in the pod list.

## Why

CronJob history limits are **count-based** (`successfulJobsHistoryLimit`), and standalone/manual Jobs (e.g. `immich-pgdump-debug`) have no `ttlSecondsAfterFinished` — so completed Jobs accumulate. This enforces an **age-based** cleanup.

## Behaviour

- Deletes **Succeeded Jobs** finished more than `TTL_SECONDS` (default **24h**) ago, across all namespaces → cascade-deletes their completed pods.
- Also sweeps orphan **Succeeded pods** older than TTL (owning job already gone).
- **Failed jobs are left untouched** → `KubeJobFailed` keeps alerting until you investigate them.
- Schedule `30 3 * * *`; TTL configurable via the `TTL_SECONDS` env var.

## Security

Least-privilege: a dedicated ServiceAccount + ClusterRole with `get/list/delete` on **jobs** and **pods** only. Non-root, read-only rootfs, drops ALL caps, seccomp RuntimeDefault.

## Validation

- `flux-local test --all-namespaces` → **82 passed**.
- `alpine/k8s:1.35.3` image confirmed present.
- **Read-only dry-run** of the selection jq against the live cluster confirmed it targets exactly the stale Succeeded jobs (orphan pgdump-debug 27h, old pgdump history, rook osd-prepare 237h, etcd-snapshot/defrag, kopia-maint) and keeps all `<24h` and non-succeeded jobs.

Note: this is intentionally cluster-wide per the request to clean everything; TTL and scope are trivial to adjust later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)