### PR TITLE
docs(job-cleaner): clarify step-2 clears node-shutdown ghost pods

### DIFF
--- a/kubernetes/apps/system-upgrade/job-cleaner/app/cronjob.yaml
+++ b/kubernetes/apps/system-upgrade/job-cleaner/app/cronjob.yaml
@@ -51,7 +51,12 @@ spec:
                         kubectl delete job -n "$${ns}" "$${name}" --ignore-not-found --wait=false
                       done
 
-                  # 2) Orphan Succeeded pods older than TTL (owning job already gone).
+                  # 2) Any Succeeded pod older than TTL: job pods whose Job is
+                  #    already gone, and "ghost" Deployment/RS pods left in the
+                  #    Succeeded phase after a graceful node shutdown (kubelet
+                  #    marks them Succeeded; the controller-manager only GCs
+                  #    terminated pods past its count threshold, so they linger).
+                  #    Their live replacements are separate Running pods, untouched.
                   kubectl get pods -A --field-selector=status.phase==Succeeded -o json \
                     | jq -r --argjson ttl "$${TTL}" '
                       .items[]


### PR DESCRIPTION
Comment-only follow-up to #406.

The step-2 comment described only "orphan pods (owning job already gone)", but the step also clears Deployment/ReplicaSet pods left in the `Succeeded` phase after a graceful node shutdown (kubelet marks them Succeeded; the controller-manager only GCs terminated pods past a count threshold, so they linger) — which was most of what the first run cleaned. Reworded to describe both cases and note that live replacements are separate Running pods that are never touched.

No behaviour change. `kustomize build` verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)