### PR TITLE
fix(network): DNS serve_stale for .internal + stop opnsense-dns crashloop

### DIFF
--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -66,6 +66,11 @@ spec:
           - name: forward
             parameters: . ${BGP_ROUTER_IP}
           - name: cache
+            configBlock: |-
+              # Serve cached .internal answers up to 1h past TTL when OPNsense
+              # (the authority for this zone) is unreachable, so a router hiccup
+              # doesn't immediately break in-cluster .internal name resolution.
+              serve_stale 1h
           - name: reload
     affinity:
       nodeAffinity:

--- a/kubernetes/apps/network/opnsense-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/opnsense-dns/app/helmrelease.yaml
@@ -11,6 +11,11 @@ spec:
   interval: 5m
   values:
     fullnameOverride: *app
+    # Give ExternalDNS 30s (default 5s) to hear back from the webhook->OPNsense
+    # API. The initial sync fatally exits on timeout, and a slow/loaded OPNsense
+    # was crashlooping this pod (~140 restarts), each restart re-hitting the API.
+    extraArgs:
+      - --webhook-provider-read-timeout=30s
     provider:
       name: webhook
       webhook:


### PR DESCRIPTION
Follow-up to the OPNsense outage: harden the cluster's DNS coupling to OPNsense and fix a chronic crashloop it aggravated.

## DNS resilience (`coredns`)
- **External DNS already uses public resolvers** — Talos node nameservers are `1.1.1.1`/`1.0.0.1`, and CoreDNS's main `.` block forwards to `/etc/resolv.conf`. So it has **no OPNsense dependency**; a classic upstream fallback would be a no-op. (When OPNsense died, external DNS broke only because OPNsense is the *gateway* — a resolver fallback can't route around a dead gateway.)
- The only true OPNsense DNS dependency is the **`.internal` zone**, where OPNsense is authoritative — no public fallback is possible. Added **`serve_stale 1h`** to that zone's cache so a brief OPNsense hang keeps `.internal` names resolving from cache instead of failing instantly.

## opnsense-dns crashloop (~140 restarts)
The `external-dns` container fatally exits when its webhook → OPNsense API call exceeds the default **5s** read timeout, restarting the pod and re-hitting the API each cycle. Raised `--webhook-provider-read-timeout=30s` so a slow/loaded OPNsense no longer trips it.

## cloudflare-tunnel crashloop (172 restarts) — no change
Its restarts are edge-discovery failures **when the cluster loses internet** (OPNsense/gateway down); k8s restart *is* the retry, and it self-heals on reconnect. The real fix is OPNsense stability, not a cloudflared change. Left as-is.

## Validation
`flux-local test --enable-helm` → **151 passed**; confirmed both values render (`--webhook-provider-read-timeout=30s` in external-dns args, `serve_stale 1h` in the CoreDNS `internal` block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)