### PR TITLE
feat(network): add Pi-hole (upstream of OPNsense)

### DIFF
--- a/kubernetes/apps/network/kustomization.yaml
+++ b/kubernetes/apps/network/kustomization.yaml
@@ -14,4 +14,5 @@ resources:
   - ./envoy-gateway/ks.yaml
   - ./echo/ks.yaml
   - ./opnsense-dns/ks.yaml
+  - ./pihole/ks.yaml
   - ./tailscale/ks.yaml

--- a/kubernetes/apps/network/pihole/app/helmrelease.yaml
+++ b/kubernetes/apps/network/pihole/app/helmrelease.yaml
@@ -1,0 +1,115 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pihole
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: pihole
+  interval: 1h
+  values:
+    controllers:
+      pihole:
+        # Single replica on a RWO Ceph volume — Pi-hole's gravity DB is SQLite
+        # and not HA. It sits UPSTREAM of OPNsense (clients -> OPNsense -> here),
+        # so a brief outage means "no filtering", not "no LAN DNS".
+        strategy: Recreate
+        containers:
+          app:
+            image:
+              repository: docker.io/pihole/pihole
+              tag: 2026.07.2
+            env:
+              TZ: Europe/Paris
+              # Forward non-blocked queries to Cloudflare public DNS. MUST NOT be
+              # OPNsense (which forwards here) — that would be a resolution loop.
+              FTLCONF_dns_upstreams: "1.1.1.1;1.0.0.1"
+              # Accept queries arriving via the LoadBalancer IP (from OPNsense),
+              # not just from localhost/local subnet.
+              FTLCONF_dns_listeningMode: "all"
+              FTLCONF_webserver_api_password:
+                valueFrom:
+                  secretKeyRef:
+                    name: pihole-secret
+                    key: FTLCONF_webserver_api_password
+            probes:
+              liveness: &probe
+                enabled: true
+              readiness: *probe
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 5
+            securityContext:
+              # Pi-hole's entrypoint runs as root (chowns /etc/pihole, drops to
+              # the pihole user) and FTL binds :53/:80, so full non-root + drop
+              # ALL is not possible. Grant only the caps it needs.
+              readOnlyRootFilesystem: false
+              capabilities:
+                add:
+                  - NET_BIND_SERVICE
+                  - CHOWN
+                  - SETUID
+                  - SETGID
+                  - DAC_OVERRIDE
+                  - SYS_NICE
+                drop: ["ALL"]
+            resources:
+              requests:
+                cpu: 25m
+              limits:
+                memory: 512Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: false
+        runAsUser: 0
+        runAsGroup: 0
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+    service:
+      # Web UI — internal only, fronted by envoy-internal below.
+      app:
+        ports:
+          http:
+            port: 80
+      # DNS — LoadBalancer on a fixed LAN IP that OPNsense forwards to.
+      dns:
+        controller: pihole
+        type: LoadBalancer
+        annotations:
+          lbipam.cilium.io/ips: 192.168.42.53
+        externalTrafficPolicy: Local
+        ports:
+          dns-tcp:
+            port: 53
+            protocol: TCP
+          dns-udp:
+            port: 53
+            protocol: UDP
+    route:
+      app:
+        annotations:
+          gatus.home-operations.com/endpoint: |-
+            alerts:
+              - type: pushover
+            conditions: ["[STATUS] < 400"]
+            ui:
+              hide-hostname: true
+        hostnames:
+          - pihole.${SECRET_DOMAIN}
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+        rules:
+          - backendRefs:
+              - identifier: app
+    persistence:
+      config:
+        existingClaim: pihole
+        globalMounts:
+          - path: /etc/pihole

--- a/kubernetes/apps/network/pihole/app/kustomization.yaml
+++ b/kubernetes/apps/network/pihole/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./secret.sops.yaml
+  - ./pvc.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/network/pihole/app/ocirepository.yaml
+++ b/kubernetes/apps/network/pihole/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas-ebx.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: pihole
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/network/pihole/app/pvc.yaml
+++ b/kubernetes/apps/network/pihole/app/pvc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pihole
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ceph-block
+  resources:
+    requests:
+      storage: 2Gi

--- a/kubernetes/apps/network/pihole/app/secret.sops.yaml
+++ b/kubernetes/apps/network/pihole/app/secret.sops.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pihole-secret
+stringData:
+  FTLCONF_webserver_api_password: ENC[AES256_GCM,data:qp8Mx3p3EDC3DJcyMDqeuBN8B6UCmz+ZrpnDKA==,iv:+JDl7j9wJOGmaBUeieD/K9R95XpMux3PBVDw848nOHM=,tag:tXENotBWbBO4CF6To72kIQ==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJRFFqdHBqRUpmUkhxNXk3
+        QS8rTm5IampCUkJJU3FFRXluamRPeWFoakZVCnZ6TXoxbE0vKzJUaVBwS1JIQ0Fm
+        YTQvMnZGaXRpUkRDNDJrVWZBKzk5RWsKLS0tIGRKa1dJTHBKaGhFeldpZEkvRDl1
+        bjQ5Y3BxMFBySUs4NkZaVjNvTVBlNTQKXvKdwqkRxFYS8qM9uvbUlsjZHbZHWNFJ
+        jUiEsKtTK2526zzmcxUuDcEH6NA8XW0vXqLLBUk1CciX4CgRXnqnrQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1ctpw7mxxzshknqmtwfn9c202hx0j57tv29fdsx4hym6hm5ed2stqtft3he
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-07-11T18:17:22Z"
+  mac: ENC[AES256_GCM,data:g8myqhy3OPLCXBpwqIA9hlE+cfElOLOWP26aM9BurLz3G4XzJVyQlhzSuT+Ud0rMYyVNGo/AH/zXcmfjXYAKIySMuXKIxzDZ1Ubl6wmsBUZmz+ESTNgslMqWsBIVykaNlr6TwxdBGbmoKasmCyYgLs7T0TQKd6vuviaD9PBOuvc=,iv:KBQY6QtBaCnCYFDfwfM4ZM70iGNyHWPkcYnyYVtwPUw=,tag:+cgRIn/4gwJAkLxHmSXnOw==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.1

--- a/kubernetes/apps/network/pihole/ks.yaml
+++ b/kubernetes/apps/network/pihole/ks.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas-ebx.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: pihole
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/network/pihole/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: network
+  wait: false


### PR DESCRIPTION
Adds Pi-hole v6 for network-wide ad-blocking, wired **upstream of OPNsense** so the cluster never becomes the LAN DNS single-point-of-failure.

## DNS flow
```
LAN clients → OPNsense (Unbound, DHCP-advertised) → Pi-hole LB 192.168.42.53:53 → 1.1.1.1/1.0.0.1
```

## What's included
- **DNS**: `LoadBalancer` on `192.168.42.53` (services pool, BGP-advertised), ports **53 TCP + 53 UDP**, `externalTrafficPolicy: Local`, `FTLCONF_dns_listeningMode=all`.
- **Web UI**: `pihole.${SECRET_DOMAIN}` via envoy-internal (internal only).
- **Password**: SOPS-encrypted `pihole-secret` → `FTLCONF_webserver_api_password`. (Generated; I'll hand it to you out of band.)
- **Storage**: 2Gi `ceph-block` PVC at `/etc/pihole`.
- **securityContext**: Pi-hole v6 must run as root (binds :53, entrypoint chowns state), so it gets a scoped cap set (`NET_BIND_SERVICE`, `CHOWN`, `SETUID/SETGID`, `DAC_OVERRIDE`, `SYS_NICE`) + writable rootfs instead of your default non-root/drop-ALL.

## ⚠️ Manual step you must do (OPNsense-side — I can't touch OPNsense)
Point OPNsense's resolver/forwarder at `192.168.42.53`, **with a fallback** (a public resolver or Unbound `forward-first`) so Pi-hole being down doesn't break LAN DNS. Do **not** point Pi-hole back at OPNsense (resolution loop).

## Caveats / decisions
- **No per-device stats**: every query reaches Pi-hole via OPNsense, so Pi-hole sees only OPNsense as the client. Inherent to this topology (the price of not making the cluster a DNS SPOF).
- **VolSync deferred**: Pi-hole runs as root, but your Kopia mover runs non-root (NFS root-squash), so it can't reliably read root-owned `/etc/pihole`. Pi-hole state is largely reconstructible; we can add backups later once the UID/perms are settled.

Validated with `flux-local test --enable-helm` → **153 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)