### PR TITLE
fix(pihole): add CAP_SETFCAP so FTL can start

### DIFF
--- a/kubernetes/apps/network/pihole/app/helmrelease.yaml
+++ b/kubernetes/apps/network/pihole/app/helmrelease.yaml
@@ -56,6 +56,11 @@ spec:
                   - SETGID
                   - DAC_OVERRIDE
                   - SYS_NICE
+                  # Pi-hole v6 entrypoint runs `setcap` on the pihole-FTL binary
+                  # (to grant it NET_BIND_SERVICE/CHOWN/SYS_NICE) before dropping
+                  # to the pihole user — that needs CAP_SETFCAP, else it errors
+                  # "Cannot run as non-root" and crashloops.
+                  - SETFCAP
                 drop: ["ALL"]
             resources:
               requests:


### PR DESCRIPTION
Follow-up to #424. Pi-hole v6's entrypoint runs `setcap` on the pihole-FTL binary before dropping to the `pihole` user; without **CAP_SETFCAP** it errors `Cannot run as non-root` and crashloops. Confirmed live: with SETFCAP added the pod runs as pihole (UID 1000), FTL listens on :53, and `dig example.com` resolves through it. Validated with flux-local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)