### PR TITLE
fix(pihole): move DNS LB IP .53 -> .101 (conflict)

### DIFF
--- a/kubernetes/apps/network/pihole/app/helmrelease.yaml
+++ b/kubernetes/apps/network/pihole/app/helmrelease.yaml
@@ -83,12 +83,16 @@ spec:
           http:
             port: 80
       # DNS — LoadBalancer on a fixed LAN IP that OPNsense forwards to.
+      # .53 was already taken by a real LAN device; .101 verified free of any
+      # host (only OPNsense proxy-ARP answers, like the working gateway IPs).
+      # NOTE: the services LB pool overlaps the DHCP range — reserve/exclude
+      # this IP in OPNsense so it can't later be leased to a device.
       dns:
         controller: pihole
         type: LoadBalancer
         annotations:
-          lbipam.cilium.io/ips: 192.168.42.53
-        externalTrafficPolicy: Local
+          lbipam.cilium.io/ips: 192.168.42.101
+        externalTrafficPolicy: Cluster
         ports:
           dns-tcp:
             port: 53


### PR DESCRIPTION
`.53` collided with an existing LAN device (pingable, non-cluster MAC `30:52:53:*`) so Pi-hole's DNS LoadBalancer never worked. `.101` is verified free of any host (only OPNsense proxy-ARP answers, like the working gateway IPs) and isn't an existing LB service. Also switched `externalTrafficPolicy` to `Cluster` (source IP is moot behind OPNsense; more robust).

⚠️ The `services` LB pool overlaps the DHCP range — reserve/exclude `.101` in OPNsense so it can't be leased later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)