### PR TITLE
fix(cilium): move services LB pool to DHCP-free .246-.254

### DIFF
--- a/kubernetes/apps/kube-system/cilium/config/pool.yaml
+++ b/kubernetes/apps/kube-system/cilium/config/pool.yaml
@@ -5,12 +5,25 @@ kind: CiliumLoadBalancerIPPool
 metadata:
   name: services
 spec:
+  # DHCP-free block (OPNsense DHCP is .54-.245) so an LB IP can never collide
+  # with a leased/static device — this is what bit the .53 Pi-hole conflict.
   allowFirstLastIPs: "Yes"
   blocks:
     - start: ${LB_POOL_START}
       stop: ${LB_POOL_STOP}
-    - start: ${LB_POOL2_START}
-      stop: ${LB_POOL2_STOP}
+---
+# Dedicated pool for the kube-api LoadBalancer (.100). That IP is also the
+# Talos control-plane VIP (L2), so API access does not depend on this pool —
+# it just preserves the existing Cilium kube-api service's requested IP.
+apiVersion: cilium.io/v2
+kind: CiliumLoadBalancerIPPool
+metadata:
+  name: api
+spec:
+  allowFirstLastIPs: "Yes"
+  blocks:
+    - start: ${CLUSTER_API_IP}
+      stop: ${CLUSTER_API_IP}
 ---
 apiVersion: cilium.io/v2
 kind: CiliumLoadBalancerIPPool

--- a/kubernetes/apps/network/pihole/app/helmrelease.yaml
+++ b/kubernetes/apps/network/pihole/app/helmrelease.yaml
@@ -83,15 +83,13 @@ spec:
           http:
             port: 80
       # DNS — LoadBalancer on a fixed LAN IP that OPNsense forwards to.
-      # .53 was already taken by a real LAN device; .101 verified free of any
-      # host (only OPNsense proxy-ARP answers, like the working gateway IPs).
-      # NOTE: the services LB pool overlaps the DHCP range — reserve/exclude
-      # this IP in OPNsense so it can't later be leased to a device.
+      # .246 is in the narrowed services pool (.246-.254), which sits ABOVE the
+      # OPNsense DHCP range (.54-.245) so it can never collide with a device.
       dns:
         controller: pihole
         type: LoadBalancer
         annotations:
-          lbipam.cilium.io/ips: 192.168.42.101
+          lbipam.cilium.io/ips: 192.168.42.246
         externalTrafficPolicy: Cluster
         ports:
           dns-tcp:

--- a/kubernetes/components/sops/cluster-secrets.sops.yaml
+++ b/kubernetes/components/sops/cluster-secrets.sops.yaml
@@ -8,10 +8,8 @@ stringData:
   CLUSTER_DNS_IP: ENC[AES256_GCM,data:lvdJFzF7nWIkCVpxaA==,iv:D0GmNiXmlEBSWUsHfO+enQNnZt7rLvXyHYGZsG2QXI8=,tag:QEHjOzlnZpQqtG9sClJ6sA==,type:str]
   CLUSTER_GATEWAY_EXTERNAL_IP: ENC[AES256_GCM,data:1KuUmBOX1QlMPiKzHR0=,iv:drN0xZCWZ9F9/eo04E/EWCgV3QNdhgAuZciYw08XEBA=,tag:ZlM/Wr6KUrTGHehmWVPSQQ==,type:str]
   CLUSTER_GATEWAY_INTERNAL_IP: ENC[AES256_GCM,data:F4/dL9t6pQTq4Fo+WUw=,iv:R3WislmKWo5poltL5LY9NJrOyywNtSPs7QG8A8SH45Q=,tag:xLAm9nWsvDYK7wSgHSKIAg==,type:str]
-  LB_POOL2_START: ENC[AES256_GCM,data:b9B6xqNPrGykflYH4Do=,iv:x6TpeAVW+92t2X0e0HeLXbxVTLXQu8Zd5dczfyLsDb4=,tag:O3cDCy2E6g1Yhk9I9n3hoQ==,type:str]
-  LB_POOL2_STOP: ENC[AES256_GCM,data:Cx7MSrJKzyrhgUGt0b4=,iv:FMoKteqYyk93+z3q7O40MYvXw1gTScfUxpS5+WrwMfs=,tag:qilQtip6IyQbc8IdbtuW3w==,type:str]
-  LB_POOL_START: ENC[AES256_GCM,data:0D5kepoC2CxlOClqxQ==,iv:aJKkGJvbzQtwcdIqN0fe0ZDAWYNcGCzyGnBCbFMQujs=,tag:7A4TafUcc/MecIpNapUQ1w==,type:str]
-  LB_POOL_STOP: ENC[AES256_GCM,data:D8JRN31ceuz/jPa5iCA=,iv:ikA6jW5rrezCBQ9Vu4a+1I6J3Nn32uWhRasRfAgwJoQ=,tag:RSV/8mlyDp70MJC/6EN14w==,type:str]
+  LB_POOL_START: ENC[AES256_GCM,data:kZDzHzWe99j4INcERr0=,iv:qfF6mxpUagsbeeb1WNDFF5HQzMHUqzapytEmIiZ13c4=,tag:MlXwhvC3Nrf9O7gtG9IgEQ==,type:str]
+  LB_POOL_STOP: ENC[AES256_GCM,data:TIPhqrasPNB2fXuPBMA=,iv:0RfAaRK7zvZvwXtLkOJfDd30CmvyE1Vad1BUNF7CARs=,tag:tR03RQmrr2noMsy1gfyl7g==,type:str]
   NAS_IP: ENC[AES256_GCM,data:7Ya1DCtOwY7h8Xkv1Q==,iv:ZINhJfanFpQj2mTGmZeyZ19FPgcARa6yjvtq8HBo+Wk=,tag:3qUxVBsG/hsLJ1G4z/Onfg==,type:str]
   NODE_IP_1: ENC[AES256_GCM,data:xi58lDTkJPObGmtPQQ==,iv:vEZ5iy5WVxh6FJOydxisG+NcExwrTKy2B768Opo1IsM=,tag:nxMpZhmdYM75v1MiR466kQ==,type:str]
   NODE_IP_2: ENC[AES256_GCM,data:Ql9bEFtMPt5KPXKzwQ==,iv:d0Fw7ir5cqzeuvAxION1+VakkLC11uSCEw2ukNB4BN0=,tag:pqaEsIG5oXH1GQU2Ip6O/g==,type:str]
@@ -21,8 +19,7 @@ stringData:
   CNPG_S3_ENDPOINT: ENC[AES256_GCM,data:kzKEZf/IPLLwvY36Lg1vF7nQJuoj5kLxxlk/jcKKUtMEtGuNxrqL45D/z0QriHoE+ui4B1Jr8NzPfnzFxfYyNkM=,iv:0lNk0qNbOhvtbcPKLmuczl1TH8wUyvXe+fEBAaihEBM=,tag:jBsCyTnBkzGUz6gy7vxwzA==,type:str]
 sops:
   age:
-    - recipient: age1ctpw7mxxzshknqmtwfn9c202hx0j57tv29fdsx4hym6hm5ed2stqtft3he
-      enc: |
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
         YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvRk1zNm45cnY4WjdTZ0Zk
         WGNrb2dIMkNYMjNtNUhYdDhsUE5zd0VRYlFzCnZqZGt2eGloczR4TFdVL1czTWN6
@@ -30,8 +27,9 @@ sops:
         a3VtMmRzSEtZcHFaT3NHZXlUaXlMd3MK25BTJAq/h02vwb5EsQAgxKypeHdoXFQd
         GG7rouwf7zlyY59zz6zp2AOpY2izVpg1tP1u5Bp2SHmt6ZApWy5Qhg==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-04-15T02:58:04Z"
-  mac: ENC[AES256_GCM,data:ap/A1uQfOOJdTqde5gGSxPW6Fom2lJMWbfnufrPGWVaFcnRO/6424dSGhVggmmHa88Inb2D1ohJxJzoVWe4DxPA3X+OshuOww4aJ0xm5ngcNxbs7NdHDUYHlFxWbeRcW3JU7METc+JLuE0ggqDC24DOsXAWMTE4lbrff2Z/hdS8=,iv:xVw9YN/wzVKapiGng5y0cXrYj2YluF0ealFXUHoLrEI=,tag:zZR12Oxe0QTEbtF4r4cReg==,type:str]
+      recipient: age1ctpw7mxxzshknqmtwfn9c202hx0j57tv29fdsx4hym6hm5ed2stqtft3he
   encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-07-12T14:20:05Z"
+  mac: ENC[AES256_GCM,data:7gGC7CmUGWmmry98EcM00XiqK8w7KyHLWMrhuxa962qmGyt6fIyXwPctpGbXuYlm3kmutpPaYFF4PimaUNuNHzypQhnbBbP399AMlSnncK5skt8vKHNnlqVhfUxMxKge+WsNO0c2gqvNGzSKmkR6zZFx9Gqp5xkR3pP24g+8clQ=,iv:QN3TUcBv+c3mmIH8fa16sr0Ld5iCvDvEcOvzsQkGZug=,tag:jU1+UZl0Z6PAzZ9sPrU5BQ==,type:str]
   mac_only_encrypted: true
   version: 3.12.2


### PR DESCRIPTION
Makes LoadBalancer IP conflicts impossible by moving the `services` pool out of the DHCP range.

## Problem
OPNsense DHCP is **`.54-.245`**, but the `services` LB pool was **`.50-.109` + `.121-.199`** — entirely inside it. So Cilium LB-IPAM could assign an IP already owned by a leased/static device. That's exactly what broke Pi-hole on `.53` (a static host below the DHCP range).

## Change
- **`services` pool → `.246-.254`** (above DHCP, verified empty — 9 IPs). Dropped the now-unused `LB_POOL2` block + secret vars.
- **New `api` pool** for the kube-api LB (`.100`). `.100` is also the **Talos control-plane VIP (L2)**, so API access never depended on the Cilium pool — this just preserves the Cilium `kube-api` service's requested IP.
- **Pi-hole DNS `.101` → `.246`** (into the new block).
- `gateways` pool (`.110-.120`) unchanged.

## Note
The `gateways` pool (`.110-.120`) and the API VIP (`.100`) still sit inside the DHCP range but have been stable (VIP is L2-held; gateways never leased). Reserve/exclude them in OPNsense to be fully safe, or shrink the DHCP range to free a bigger LB block if you want to move them too.

Validated with `flux-local test --enable-helm` → **153 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)