### PR TITLE
fix(emby): drop broken LoadBalancer, use the route

### DIFF
--- a/kubernetes/apps/media/emby/app/helmrelease.yaml
+++ b/kubernetes/apps/media/emby/app/helmrelease.yaml
@@ -69,10 +69,10 @@ spec:
                 memory: 4Gi
     service:
       app:
-        type: LoadBalancer
-        annotations:
-          lbipam.cilium.io/ips: ${CLUSTER_GATEWAY_INTERNAL_IP}
-        externalTrafficPolicy: Local
+        # ClusterIP — Emby is reached via the envoy-internal route below
+        # (emby.${SECRET_DOMAIN}). The previous LoadBalancer pinned itself to
+        # the internal gateway's own IP (.110), which conflicted with
+        # envoy-internal and left the service permanently Pending.
         ports:
           http:
             port: *port


### PR DESCRIPTION
Emby's Service was `type: LoadBalancer` pinned to `${CLUSTER_GATEWAY_INTERNAL_IP}` (**.110 — the internal gateway's own IP**), so it conflicted with `envoy-internal` and stayed permanently `Pending`. Emby already has an `envoy-internal` route (`emby.${SECRET_DOMAIN}`) — the actual access path — and the LB only re-exposed the same 8096 port. Switched the Service to **ClusterIP** (the route backends to it). Nothing relied on the LB (it never got an IP). Validated with flux-local (153 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)