### PR TITLE
fix(nextcloud): bump postgres storage 15Gi -> 30Gi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 # Kubernetes
 kubeconfig
 talosconfig
+.kube/
 # Misc.
 CLAUDE.md
 .claude/

--- a/kubernetes/apps/selfhosted/nextcloud/app/cluster.yaml
+++ b/kubernetes/apps/selfhosted/nextcloud/app/cluster.yaml
@@ -10,7 +10,7 @@ spec:
   imageName: ghcr.io/cloudnative-pg/postgresql:16
   storage:
     storageClass: ceph-block
-    size: 15Gi
+    size: 30Gi
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
## Contexte

`nextcloud-postgres` était bloqué en `Not enough disk space` : les volumes de `nextcloud-postgres-3` et `-4` étaient remplis à **99.9% de 15Gi**, les 3 instances crashloopaient (796 et 336 restarts) et **nextcloud lui-même était down**.

Ces clusters n'ont pas de `walStorage`, donc les WAL partagent le volume de données — une fois plein, PostgreSQL n'a plus assez de marge pour démarrer du tout.

## Changement

`spec.storage.size` : 15Gi → 30Gi.

## Déjà appliqué en live

Le resize a été fait à chaud pour rétablir le service ; ce commit aligne git dessus pour que Flux ne revienne pas à 15Gi.

À noter, bumper `spec.storage.size` seul n'a **pas** suffi — l'opérateur ne propage pas la taille aux PVC quand le cluster est déjà wedged en low-disk. Il a fallu patcher les PVC directement, puis supprimer les pods : kubelet ne fait le `resize2fs` qu'au remount, et un conteneur en crashloop ne remonte jamais. Sans ça le block device faisait 30Gi mais le filesystem restait à 15G.

## Vérification

- `df` sur `nextcloud-postgres-3` : `30G  15G  15G  50%`
- `kubectl get cluster -n selfhosted` : `nextcloud-postgres` → `Cluster in healthy state`, 3/3 ready
- alertes actives : 27 → 11, plus aucune sur nextcloud

## Suivi séparé

- 30Gi ne fait que repousser l'échéance si c'est l'accumulation de WAL qui remplit — un `walStorage` dédié serait le vrai fix. La répartition WAL/data n'a pas pu être mesurée pendant l'incident (conteneurs postgres morts, sidecar distroless sans shell).
- Les répliques `immich-postgres-5` et `nextcloud-postgres-5` étaient par ailleurs divergées sur une timeline incompatible (~1690 restarts chacune sur 7 jours) et ont été re-clonées. Hors périmètre de cette PR, aucun changement de manifeste nécessaire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)