### PR TITLE
chore(gitignore): ignore .kube/ to prevent accidental kubeconfig commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 # Kubernetes
 kubeconfig
 talosconfig
+.kube/
 # Misc.
 CLAUDE.md
 .claude/


### PR DESCRIPTION
## Changement

Ajoute `.kube/` à `.gitignore`, aux côtés de `kubeconfig` et `talosconfig` déjà présents dans la section Kubernetes.

## Pourquoi

Le répertoire `.kube/` apparaît en untracked à la racine du repo et contient des credentials cluster. `kubeconfig` était déjà ignoré, mais pas le répertoire — un `git add .` un peu large suffirait à committer des credentials en clair.

Une ligne, aucun impact sur les manifestes ni sur Flux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)