### PR TITLE
fix(cnpg): cap WAL retained by inactive replication slots + alert on it

### DIFF
--- a/kubernetes/apps/observability/cluster-rules/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/cluster-rules/app/prometheusrule.yaml
@@ -55,6 +55,43 @@ spec:
             description: "Le dernier backup du cluster CNPG {{ $labels.cluster }} ({{ $labels.namespace }}) a échoué et aucun n'a réussi depuis."
 
     # =========================
+    # WAL CNPG — détection de la rétention par slot inactif.
+    # Le 2026-07-20, la réplique nextcloud-postgres-5 (divergée sur sa timeline)
+    # a crashloopé 7j en gardant son slot déclaré mais inactif : ~14GB de WAL
+    # empilés pour une base de 42MB, volume saturé, cluster entier à terre.
+    # max_slot_wal_keep_size=4GB est le garde-fou ; ces alertes préviennent AVANT
+    # qu'il ne se déclenche, pour re-cloner la réplique sans perdre le slot.
+    # =========================
+    - name: cnpg-wal.rules
+      rules:
+        - alert: CNPGReplicationSlotInactive
+          # Chaque instance publie la métrique pour TOUS les slots du cluster :
+          # les répliques rapportent 0 pour les slots qu'elles ne possèdent pas.
+          # Un `== 0` nu fanionnerait donc en permanence. Le max by() dit "aucune
+          # instance ne voit ce slot actif", seul cas qui compte réellement.
+          expr: |
+            max by (namespace, job, slot_name) (cnpg_pg_replication_slots_active) == 0
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Slot de réplication CNPG inactif"
+            description: "Le slot {{ $labels.slot_name }} ({{ $labels.namespace }}/{{ $labels.job }}) est inactif depuis plus de 30min et retient du WAL. Vérifier la réplique correspondante — si elle est morte, la re-cloner (delete PVC + pod)."
+
+        - alert: CNPGWalVolumeGrowing
+          # Régime normal ~0.6-1.5GB (max_wal_size=1GB, wal_keep_size=512MB).
+          # 3GB = anomalie franche, et laisse 1GB de marge avant que le plafond
+          # max_slot_wal_keep_size (4GB) n'invalide un slot.
+          expr: |
+            cnpg_collector_pg_wal{value="size"} > 3e9
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "WAL CNPG en accumulation"
+            description: "Le pg_wal de {{ $labels.pod }} ({{ $labels.namespace }}) fait {{ $value | humanize1024 }}B, bien au-delà du régime normal. Slot inactif ou archivage bloqué — le plafond de 4GB va invalider un slot si ça continue."
+
+    # =========================
     # Disque OS des nodes Talos (cache containerd)
     # =========================
     - name: node-disk.rules

--- a/kubernetes/apps/selfhosted/immich/app/cluster.yaml
+++ b/kubernetes/apps/selfhosted/immich/app/cluster.yaml
@@ -15,6 +15,17 @@ spec:
     # space") until the PVC is enlarged. Headroom to ride out future archiving
     # outages without wedging the primary.
     size: 20Gi
+  postgresql:
+    parameters:
+      # Plafonne le WAL qu'un slot de réplication peut retenir. Par défaut
+      # max_slot_wal_keep_size = -1 (illimité) : une réplique morte garde son
+      # slot déclaré mais inactif, et PostgreSQL conserve indéfiniment le WAL
+      # dont elle aurait besoin — jusqu'à saturer le volume et faire tomber TOUT
+      # le cluster, primary compris (c'est ce qui a tué nextcloud-postgres le
+      # 2026-07-20, et l'incident de 2026-06 ci-dessus). Au-delà du plafond, le
+      # slot est invalidé : la réplique en retard doit être re-clonée, mais le
+      # cluster survit. 4GB = ~4x le régime normal (max_wal_size 1GB).
+      max_slot_wal_keep_size: 4GB
   resources:
     requests:
       cpu: 100m

--- a/kubernetes/apps/selfhosted/nextcloud/app/cluster.yaml
+++ b/kubernetes/apps/selfhosted/nextcloud/app/cluster.yaml
@@ -10,7 +10,20 @@ spec:
   imageName: ghcr.io/cloudnative-pg/postgresql:16
   storage:
     storageClass: ceph-block
+    # 30Gi (was 15Gi) : le volume combiné data+WAL a saturé le 2026-07-20 et
+    # CNPG s'est bloqué en "Not enough disk space" jusqu'à l'agrandissement.
+    # La base ne fait que 42MB — c'était du WAL retenu, cf. max_slot_wal_keep_size.
     size: 30Gi
+  postgresql:
+    parameters:
+      # Plafonne le WAL qu'un slot de réplication peut retenir. Par défaut
+      # max_slot_wal_keep_size = -1 (illimité) : la réplique -5, divergée sur sa
+      # timeline et crashloopée pendant 7j, a gardé son slot inactif et fait
+      # empiler ~14GB de WAL pour une base de 42MB — jusqu'à saturer les 15Gi et
+      # faire tomber les 3 instances, primary compris. Au-delà du plafond, le
+      # slot est invalidé : la réplique en retard doit être re-clonée, mais le
+      # cluster survit. 4GB = ~4x le régime normal (max_wal_size 1GB).
+      max_slot_wal_keep_size: 4GB
   resources:
     requests:
       cpu: 100m
@@ -21,6 +34,15 @@ spec:
     initdb:
       database: nextcloud
       owner: nextcloud
+      postInitApplicationSQL:
+        # La base nextcloud porte une ACL explicite ({nextcloud=CTc/nextcloud}),
+        # ce qui révoque le CONNECT implicite de PUBLIC. Sans ce GRANT, le
+        # collecteur CNPG échoue en "permission denied for database" et n'expose
+        # AUCUNE métrique cnpg_pg_replication_slots_* pour ce cluster — le trou
+        # exact qui a laissé la rétention WAL du 2026-07-20 passer inaperçue.
+        # (immich a datacl=NULL, donc PUBLIC peut se connecter : pas concerné.)
+        # Appliqué à chaud sur le cluster existant, ceci ne couvre qu'un rebuild.
+        - GRANT CONNECT ON DATABASE nextcloud TO cnpg_metrics_exporter;
   plugins:
     - name: barman-cloud.cloudnative-pg.io
       isWALArchiver: true


### PR DESCRIPTION
## Ce qui s'est réellement passé

Une base nextcloud de **42 MB** a rempli un volume de **15 GB** et fait tomber les 3 instances, primary compris.

Ce n'était pas la base qui grossissait. La réplique `nextcloud-postgres-5` a divergé sur sa timeline (`requested timeline 21 does not contain minimum recovery point 46/88000000 on timeline 20`), a crashloopé **7 jours**, et a gardé son slot de réplication déclaré mais inactif. Avec `max_slot_wal_keep_size = -1` (illimité, le défaut), PostgreSQL a conservé tout le WAL dont cette réplique morte aurait pu avoir besoin — ~14 GB — jusqu'à saturation.

Preuve : une fois la réplique re-clonée et l'archivage reparti, le WAL est retombé à **593 MB** et le volume de 50% à 3%.

## Pourquoi pas simplement agrandir le volume

C'est la réponse qui a déjà été apportée **deux fois** — immich en 2026-06 (cf. le commentaire dans `immich/cluster.yaml`) et nextcloud le 2026-07-20. Elle déplace le plafond sans traiter la cause. Un slot sans borne finira par remplir n'importe quelle taille de volume.

`max_slot_wal_keep_size: 4GB` traite la cause : au-delà, le slot est invalidé. La réplique en retard doit être re-clonée, mais le cluster survit. 4 GB ≈ 4x le régime normal (`max_wal_size` 1GB, `wal_keep_size` 512MB, WAL observé ~600MB).

À noter, `walStorage` dédié — envisagé puis écarté — n'aurait **pas** empêché cette panne : un slot sans borne remplit un volume WAL dédié exactement pareil, et un `pg_wal` plein arrête PostgreSQL de toute façon. C'est aussi une porte à sens unique (`removing walStorage from an existing cluster is not supported`).

## La détection qui manquait

Ces répliques ont crashé 7 jours sans réaction. Deux alertes ajoutées dans `cluster-rules` :

- **`CNPGReplicationSlotInactive`** — le `max by (namespace, job, slot_name)` n'est pas cosmétique : chaque instance publie la métrique pour *tous* les slots du cluster, et les répliques rapportent `0` pour ceux qu'elles ne possèdent pas. Un `== 0` nu fanionnerait en permanence.
- **`CNPGWalVolumeGrowing`** — seuil à 3GB, sous le plafond de 4GB, pour prévenir *avant* que le garde-fou n'invalide un slot.

## Le trou dans le trou

Nextcloud n'exposait **aucune** métrique de slot. Sa base porte une ACL explicite (`{nextcloud=CTc/nextcloud}`) qui révoque le CONNECT implicite de PUBLIC ; le collecteur CNPG échouait en `permission denied for database "nextcloud"`. immich a `datacl=NULL`, d'où l'asymétrie.

L'alerte de cette PR n'aurait donc pas couvert le cluster qui vient précisément de mourir de ce problème. `GRANT CONNECT` appliqué à chaud, et consigné dans `postInitApplicationSQL` pour les rebuilds.

## Vérifications

- `max_slot_wal_keep_size` = **4GB** effectif sur les deux primaries (paramètre `sighup`, aucun redémarrage)
- les deux clusters restent `Cluster in healthy state` 3/3
- les deux expressions d'alerte retournent **0 série** contre le Prometheus live — pas de faux positif à l'état sain
- `max by(...)` remonte bien `= 1` sur les slots actifs (l'alerte n'est pas muette pour autant)
- nextcloud expose désormais ses 2 slots, `cnpg_errors_total` à **0**

## Limite connue

Le `GRANT` a été appliqué à chaud ; le `postInitApplicationSQL` ne s'exécute qu'au bootstrap et ne couvre donc qu'un rebuild futur. Les deux sont désormais alignés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)