### PR TITLE
fix(cluster-rules): drop duplicated namespace in CNPG slot alert description

### DIFF
--- a/kubernetes/apps/observability/cluster-rules/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/cluster-rules/app/prometheusrule.yaml
@@ -76,7 +76,9 @@ spec:
             severity: warning
           annotations:
             summary: "Slot de réplication CNPG inactif"
-            description: "Le slot {{ $labels.slot_name }} ({{ $labels.namespace }}/{{ $labels.job }}) est inactif depuis plus de 30min et retient du WAL. Vérifier la réplique correspondante — si elle est morte, la re-cloner (delete PVC + pod)."
+            # $labels.job vaut déjà "<namespace>/<cluster>" : ne pas le préfixer
+            # du namespace, ça rendait "selfhosted/selfhosted/immich-postgres".
+            description: "Le slot {{ $labels.slot_name }} ({{ $labels.job }}) est inactif depuis plus de 30min et retient du WAL. Vérifier la réplique correspondante — si elle est morte, la re-cloner (delete PVC + pod)."
 
         - alert: CNPGWalVolumeGrowing
           # Régime normal ~0.6-1.5GB (max_wal_size=1GB, wal_keep_size=512MB).


### PR DESCRIPTION
## Contexte

En déclenchant `CNPGReplicationSlotInactive` pour de vrai (slot de test → `pending` → `firing` → Alertmanager), la description rendue était :

> Le slot test_alert_inactive_slot (**selfhosted/selfhosted**/immich-postgres) est inactif...

Le label `job` du PodMonitor vaut déjà `<namespace>/<cluster>`. Le préfixer de `{{ $labels.namespace }}` dupliquait donc le namespace.

## Changement

Une ligne : `{{ $labels.namespace }}/{{ $labels.job }}` → `{{ $labels.job }}`, avec un commentaire pour éviter la récidive. Purement cosmétique, la logique de l'alerte est inchangée.

## À noter

Ce défaut n'était pas visible en lisant le template — il fallait faire réellement partir l'alerte pour le voir. La vérification de bout en bout (PR #450) a par ailleurs confirmé que l'expression matche exactement le slot inactif et aucun des slots actifs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)