### PR TITLE
docs(cnpg): record why walStorage is deliberately absent

### DIFF
--- a/kubernetes/apps/selfhosted/immich/app/cluster.yaml
+++ b/kubernetes/apps/selfhosted/immich/app/cluster.yaml
@@ -15,6 +15,17 @@ spec:
     # space") until the PVC is enlarged. Headroom to ride out future archiving
     # outages without wedging the primary.
     size: 20Gi
+  # Pas de walStorage dédié — décision explicite du 2026-07-20, ne pas "corriger".
+  # Le stockage est mono-pool/mono-device : 1 StorageClass (ceph-block), 1 pool
+  # (ceph-blockpool), 3 OSDs = un seul NVMe par node (osdsPerDevice: 1). Un PVC
+  # WAL séparé serait une autre image RBD sur les MÊMES OSDs et les MÊMES disques
+  # — séparation logique, zéro isolation I/O. Et aucune contention à résoudre :
+  # 134 KiB/s wr cluster-wide, latences OSD 5-6ms, débit WAL immich 0 MB/h.
+  # Le coût serait réel : re-cloner toutes les instances (switchover pour le
+  # primary) et c'est IRRÉVERSIBLE ("removing walStorage from an existing cluster
+  # is not supported"). À noter : le webhook CNPG 1.30 accepte pourtant le champ
+  # en dry-run — son acceptation ne dit RIEN de la faisabilité de la migration.
+  # À rouvrir seulement avec un 2e NVMe par node → device class + pool + SC dédiés.
   postgresql:
     parameters:
       # Plafonne le WAL qu'un slot de réplication peut retenir. Par défaut

--- a/kubernetes/apps/selfhosted/nextcloud/app/cluster.yaml
+++ b/kubernetes/apps/selfhosted/nextcloud/app/cluster.yaml
@@ -14,6 +14,12 @@ spec:
     # CNPG s'est bloqué en "Not enough disk space" jusqu'à l'agrandissement.
     # La base ne fait que 42MB — c'était du WAL retenu, cf. max_slot_wal_keep_size.
     size: 30Gi
+  # Pas de walStorage dédié — décision explicite du 2026-07-20, ne pas "corriger".
+  # Rationale complet dans immich/app/cluster.yaml : stockage mono-pool/mono-device
+  # (1 NVMe par node), donc un PVC WAL séparé n'apporte aucune isolation I/O, pour
+  # un coût irréversible. Écarté aussi comme remède à la saturation : un slot sans
+  # borne remplit un volume dédié tout autant — c'est max_slot_wal_keep_size qui
+  # traite la cause, ci-dessous.
   postgresql:
     parameters:
       # Plafonne le WAL qu'un slot de réplication peut retenir. Par défaut


### PR DESCRIPTION
## Pourquoi cette note

La question de `walStorage` s'est posée **deux fois** dans la même session — d'abord comme remède au volume saturé, puis pour l'isolation I/O — et la réponse a été non les deux fois, pour des raisons différentes. Sans trace dans les manifestes, un futur passage voit un cluster CNPG sans `walStorage` et le lit comme un oubli à corriger.

## Le fond

**Comme remède à la saturation : inopérant.** Un slot de réplication sans borne remplit un volume WAL dédié exactement comme un volume partagé, et un `pg_wal` plein arrête PostgreSQL de toute façon. C'est `max_slot_wal_keep_size` (PR #450) qui traite la cause.

**Comme isolation I/O : inatteignable dans cette topologie.**

```
1 StorageClass  : ceph-block
1 pool          : ceph-blockpool
3 OSDs          : un par node
1 NVMe par node : BIWIN NV7200 1TB (osdsPerDevice: 1)
```

Un PVC `walStorage` serait une autre image RBD **dans le même pool, sur les mêmes OSDs, sur les mêmes NVMe**. Séparation logique, zéro séparation physique.

Et il n'y a aucune contention à soulager : `client io` 134 KiB/s wr / 13 op/s wr, `ceph osd perf` 5-6 ms, HEALTH_OK, débit WAL immich 0 MB/h. Face à ça, le coût serait de re-cloner les 6 instances avec switchover sur les primaries, **irréversible** (`removing walStorage from an existing cluster is not supported`).

## Le piège consigné

Le webhook CNPG 1.30 **accepte** `walStorage` en dry-run server-side. Pris pour un feu vert, ce test enverrait le prochain lecteur droit dans la migration — l'acceptation du webhook ne dit rien de sa faisabilité. C'est noté explicitement dans le commentaire.

## Portée

Commentaires uniquement. Vérifié : 17 insertions, **aucune ligne non-commentaire modifiée**, et les deux specs parsent à l'identique (`walStorage` absent des deux). Aucun impact live.

## Si le matériel évolue

Un 2e NVMe par node → device class Ceph dédiée → pool + StorageClass séparés → `walStorage` dessus. C'est la seule voie vers une vraie isolation, et le commentaire y renvoie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)